### PR TITLE
feat: Use next string array instead of string

### DIFF
--- a/packages/js/src/make_script_data/make_output_script_data.ts
+++ b/packages/js/src/make_script_data/make_output_script_data.ts
@@ -86,9 +86,9 @@ async function main() {
                 ? current_next.indexOf(next_char) === -1
                   ? // if the next char is not in the current next, then add it to the current next
                     // else ignore it
-                    current_next + next_char
+                    [...current_next, next_char]
                   : current_next
-                : next_char;
+                : [next_char];
           // mapping the krama index
           if (i === text.length - 1) {
             res.text_to_krama_map[existing_entry_index][1].krama = val;
@@ -97,7 +97,7 @@ async function main() {
           }
           continue;
         }
-        res.text_to_krama_map.push([text_char, { ...(next_char ? { next: next_char } : {}) }]);
+        res.text_to_krama_map.push([text_char, { ...(next_char ? { next: [next_char] } : {}) }]);
         // mapping the krama index
         if (i === text.length - 1) {
           res.text_to_krama_map[res.text_to_krama_map.length - 1][1].krama = val;

--- a/packages/js/src/make_script_data/output_script_data_schema.ts
+++ b/packages/js/src/make_script_data/output_script_data_schema.ts
@@ -13,7 +13,7 @@ type CommonScriptData = {
   text_to_krama_map: [
     text: string,
     {
-      next?: string | null;
+      next?: string[] | null;
       /** Multiple krama index references are useful to some intermediate states. For eg:- Normal A -> A, AU -> A, U and AUM -> AUM
        * This will be useful only when there are more than two transition states. As double transition state outputs dont need multiple krama references.
        * For eg -> The Bengali kz (actually k + nukta) will be a two step mapping, k -> k (next :nukta,... ) and k+nukta->kz krama reference in the main transliteration array


### PR DESCRIPTION
This will be useful for Scripts that have non-bmp code points whose length is more than one in JS (UTF-16)
