### PR TITLE
feat: Distribute the WASM directly as .wasm instead of base64

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -36,7 +36,13 @@
       "types": "./dist/typing.d.ts",
       "import": "./dist/esm/typing.mjs",
       "require": "./dist/cjs/typing.cjs"
-    }
+    },
+    "./slim": {
+      "types": "./dist/index_slim.d.ts",
+      "import": "./dist/esm/slim.mjs",
+      "require": "./dist/cjs/slim.cjs"
+    },
+    "./wasm": "./dist/esm/lipilekhika_wasm_bg.wasm"
   },
   "files": [
     "dist"

--- a/packages/js/src/index_slim.ts
+++ b/packages/js/src/index_slim.ts
@@ -1,0 +1,6 @@
+export * from './index_main';
+export * from './index_wasm_slim';
+
+// Slim entrypoint — WASM binary is NOT embedded inline.
+// Ship/co-locate `lipilekhika_wasm_bg.wasm` alongside the JS, or pass
+// the source explicitly via initWasm().

--- a/packages/js/src/index_wasm_slim.ts
+++ b/packages/js/src/index_wasm_slim.ts
@@ -1,0 +1,52 @@
+import { getNormalizedScriptName, type ScriptLangType } from './index_main';
+import type { CustomOptionType } from './transliteration/transliterate';
+
+// Re-export initWasm and preloadWasm through the lazy loader to avoid
+// dual static+dynamic import of bind_slim in the same module.
+export type { InitInput } from '../wasm/bind_slim';
+
+let wasmModulePromise: Promise<typeof import('../wasm/bind_slim')> | null = null;
+const loadWasmModule = () => {
+  if (!wasmModulePromise) {
+    wasmModulePromise = import('../wasm/bind_slim');
+  }
+  return wasmModulePromise;
+};
+
+export const initWasm: typeof import('../wasm/bind_slim')['initWasm'] = (source) =>
+  loadWasmModule().then((m) => m.initWasm(source));
+
+export const preloadWasm: typeof import('../wasm/bind_slim')['preloadWasm'] = (source) =>
+  loadWasmModule().then((m) => m.preloadWasm(source));
+
+/**
+ * WASM(Rust) based transliteration — slim variant.
+ *
+ * You MUST call `initWasm(wasmSource)` before using this function.
+ *
+ * Transliterates `text` from `from` to `to`.
+ * @param text - The text to transliterate
+ * @param from - The script/language to transliterate from
+ * @param to - The script/language to transliterate to
+ * @param trans_options - The custom transliteration options to use for the transliteration
+ * @returns The transliterated text
+ */
+export async function transliterate_wasm(
+  text: string,
+  from: ScriptLangType,
+  to: ScriptLangType,
+  trans_options?: CustomOptionType
+) {
+  const normalized_from = getNormalizedScriptName(from);
+  if (!normalized_from) {
+    throw new Error(`Invalid script name: ${from}`);
+  }
+  const normalized_to = getNormalizedScriptName(to);
+  if (!normalized_to) {
+    throw new Error(`Invalid script name: ${to}`);
+  }
+  if (normalized_from === normalized_to) return text;
+  const wasm_mod = await loadWasmModule();
+  const result = await wasm_mod.transliterate(text, normalized_from, normalized_to, trans_options);
+  return result;
+}

--- a/packages/js/vite.config.ts
+++ b/packages/js/vite.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
   plugins: [
     dts({ include: ['src'], outDir: 'dist/types' }),
     MacroPlugin(),
-    ...(IS_UMD_BUILD_MODE ? [copyAndMinifyJsonPlugin()] : [copyNativeBinariesPlugin()])
+    ...(IS_UMD_BUILD_MODE
+      ? [copyAndMinifyJsonPlugin()]
+      : [copyNativeBinariesPlugin(), copyWasmFilePlugin()])
   ],
   build: {
     lib: {
@@ -21,12 +23,13 @@ export default defineConfig({
         : {
             index: path.resolve(__dirname, 'src/index.ts'),
             node: path.resolve(__dirname, 'src/node.ts'),
-            typing: path.resolve(__dirname, 'src/typing.ts')
+            typing: path.resolve(__dirname, 'src/typing.ts'),
+            slim: path.resolve(__dirname, 'src/index_slim.ts')
           },
       name: 'lipilekhika', // used for UMD/iife global when loaded via <script>
       // formats: ["es", "cjs", "iife", "umd"],
       fileName: (format, entryName) => {
-        // For multi-entry ESM/CJS builds, emit `index.*` and `typing.*`
+        // For multi-entry ESM/CJS builds, emit `index.*`, `typing.*`, `slim.*`
         const base = entryName ?? 'index';
         return `${base}.${format === 'es' ? 'mjs' : 'cjs'}`;
       }
@@ -38,7 +41,8 @@ export default defineConfig({
         : {
             index: path.resolve(__dirname, 'src/index.ts'),
             node: path.resolve(__dirname, 'src/node.ts'),
-            typing: path.resolve(__dirname, 'src/typing.ts')
+            typing: path.resolve(__dirname, 'src/typing.ts'),
+            slim: path.resolve(__dirname, 'src/index_slim.ts')
           },
       output: !IS_UMD_BUILD_MODE
         ? [
@@ -88,6 +92,30 @@ function copyNativeBinariesPlugin(): Plugin {
       for (const nativeBinaryFile of nativeBinaryFiles) {
         fs.copyFileSync(path.join(srcDir, nativeBinaryFile), path.join(destDir, nativeBinaryFile));
       }
+    }
+  };
+}
+
+/**
+ * Copies the .wasm binary into dist/esm and dist/cjs so consumers of the
+ * `lipilekhika/slim` entrypoint (and the `lipilekhika/wasm` export) can
+ * reference it as a static asset without bundling it inline.
+ */
+function copyWasmFilePlugin(): Plugin {
+  return {
+    name: 'copy-wasm-file',
+    closeBundle: async () => {
+      const wasmSrc = path.resolve(__dirname, 'wasm/pkg/lipilekhika_wasm_bg.wasm');
+      if (!fs.existsSync(wasmSrc)) return;
+
+      const destESM = path.resolve(__dirname, 'dist/esm/lipilekhika_wasm_bg.wasm');
+      const destCJS = path.resolve(__dirname, 'dist/cjs/lipilekhika_wasm_bg.wasm');
+
+      fs.mkdirSync(path.dirname(destESM), { recursive: true });
+      fs.mkdirSync(path.dirname(destCJS), { recursive: true });
+
+      fs.copyFileSync(wasmSrc, destESM);
+      fs.copyFileSync(wasmSrc, destCJS);
     }
   };
 }

--- a/packages/js/wasm/bind_slim.ts
+++ b/packages/js/wasm/bind_slim.ts
@@ -1,0 +1,81 @@
+// Slim binding - does NOT inline WASM as base64.
+// Consumer must call initWasm() with the WASM source before using transliterate.
+import init, {
+  transliterate as wasmTransliterate,
+  initSync
+} from './pkg/lipilekhika_wasm.js';
+import type { InitInput, SyncInitInput } from './pkg/lipilekhika_wasm.js';
+import type { TransliterationOptions } from '../src/index';
+
+export type { InitInput, SyncInitInput } from './pkg/lipilekhika_wasm.js';
+
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Initialize the WASM module with an external WASM source.
+ *
+ * In the slim entrypoint the WASM binary is NOT bundled inline.
+ * You must call this before using any WASM-backed functions.
+ *
+ * @example
+ * // Vite
+ * import wasmUrl from 'lipilekhika/wasm?url';
+ * await initWasm(wasmUrl);
+ *
+ * @example
+ * // Next.js / manual fetch
+ * await initWasm(fetch('/path/to/lipilekhika_wasm_bg.wasm'));
+ *
+ * @example
+ * // Node.js (fs)
+ * import fs from 'node:fs';
+ * await initWasm(fs.readFileSync('./lipilekhika_wasm_bg.wasm'));
+ *
+ * @param wasmSource - A URL string, URL object, Response, fetch() Promise,
+ *   ArrayBuffer, or WebAssembly.Module. If omitted, falls back to default
+ *   `import.meta.url`-relative resolution (requires the .wasm file to be
+ *   co-located with the JS — NOT reliable across all bundlers).
+ */
+export async function initWasm(wasmSource?: InitInput | SyncInitInput): Promise<void> {
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    if (wasmSource !== undefined) {
+      // If it's a synchronous buffer, use initSync for zero async overhead
+      if (
+        wasmSource instanceof ArrayBuffer ||
+        ArrayBuffer.isView(wasmSource) ||
+        wasmSource instanceof WebAssembly.Module
+      ) {
+        initSync({ module: wasmSource as SyncInitInput });
+      } else {
+        await init(wasmSource as InitInput);
+      }
+    } else {
+      // Fallback: attempt default URL resolution (only works if .wasm is co-located)
+      await init();
+    }
+  })();
+
+  return initPromise;
+}
+
+/**
+ * Pre-loads the WASM module. Same as calling initWasm() manually.
+ */
+export const preloadWasm = initWasm;
+
+export async function transliterate(
+  text: string,
+  from: string,
+  to: string,
+  trans_options?: TransliterationOptions | null
+): Promise<string> {
+  if (!initPromise) {
+    throw new Error(
+      '[lipilekhika/slim] WASM not initialized. Call `initWasm(wasmSource)` before using transliterate_wasm.'
+    );
+  }
+  await initPromise;
+  return wasmTransliterate(text, from, to, trans_options);
+}


### PR DESCRIPTION
In `gzip` compression it leads to a 46kB less file size, and uncompressed the difference is about 124kB

- But this introduce complexities too


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `./slim` and `./wasm` library entry points for alternative module loading options.
  * Introduced `transliterate_wasm()` async function powered by WebAssembly for improved performance.
  * Enabled external WASM binary loading for flexible deployment strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->