### PR TITLE
fix-rust: Use CustomOptions struct for transliteratio and remove hashbrown::HashMap leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ dependencies = [
  "bincode",
  "clap",
  "criterion",
+ "derive_builder",
  "foldhash 0.1.5",
  "hashbrown 0.15.5",
  "indexmap 2.12.1",

--- a/desktop-client/lipiparivartaka/src-tauri/src/lib.rs
+++ b/desktop-client/lipiparivartaka/src-tauri/src/lib.rs
@@ -11,16 +11,32 @@ struct Payload {
   options: Option<HashMap<String, bool>>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(tag = "code", content = "details", rename_all = "snake_case")]
+enum TransliterateError {
+  InvalidScript { field: &'static str, value: String },
+  InvalidCustomOptionKey,
+}
+
+fn parse_script(field: &'static str, value: &str) -> Result<Script, TransliterateError> {
+  Script::from_str(value).map_err(|_| TransliterateError::InvalidScript {
+    field,
+    value: value.to_string(),
+  })
+}
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command(rename_all = "snake_case")]
-fn transliterate(payload: Payload) -> String {
-  let from = Script::from_str(&payload.from).unwrap();
-  let to = Script::from_str(&payload.to).unwrap();
-  let options = payload.options.as_ref().map(|options| {
-    lipilekhika::CustomOptions::try_from_map(options)
-      .expect("desktop payload custom option keys must be canonical")
-  });
-  transliterate_impl(&payload.text, from, to, options.as_ref()).into_owned()
+fn transliterate(payload: Payload) -> Result<String, TransliterateError> {
+  let from = parse_script("from", &payload.from)?;
+  let to = parse_script("to", &payload.to)?;
+  let options = payload
+    .options
+    .as_ref()
+    .map(lipilekhika::CustomOptions::try_from_map)
+    .transpose()
+    .map_err(|_| TransliterateError::InvalidCustomOptionKey)?;
+  Ok(transliterate_impl(&payload.text, from, to, options.as_ref()).into_owned())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/desktop-client/lipiparivartaka/src-tauri/src/lib.rs
+++ b/desktop-client/lipiparivartaka/src-tauri/src/lib.rs
@@ -16,7 +16,14 @@ struct Payload {
 fn transliterate(payload: Payload) -> String {
   let from = Script::from_str(&payload.from).unwrap();
   let to = Script::from_str(&payload.to).unwrap();
-  transliterate_impl(&payload.text, from, to, payload.options.as_ref()).into_owned()
+  let options = payload
+    .options
+    .as_ref()
+    .map(|options| {
+      lipilekhika::CustomOptions::try_from_map(options)
+      .expect("desktop payload custom option keys must be canonical")
+    });
+  transliterate_impl(&payload.text, from, to, options.as_ref()).into_owned()
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/desktop-client/lipiparivartaka/src-tauri/src/lib.rs
+++ b/desktop-client/lipiparivartaka/src-tauri/src/lib.rs
@@ -16,13 +16,10 @@ struct Payload {
 fn transliterate(payload: Payload) -> String {
   let from = Script::from_str(&payload.from).unwrap();
   let to = Script::from_str(&payload.to).unwrap();
-  let options = payload
-    .options
-    .as_ref()
-    .map(|options| {
-      lipilekhika::CustomOptions::try_from_map(options)
+  let options = payload.options.as_ref().map(|options| {
+    lipilekhika::CustomOptions::try_from_map(options)
       .expect("desktop payload custom option keys must be canonical")
-    });
+  });
   transliterate_impl(&payload.text, from, to, options.as_ref()).into_owned()
 }
 

--- a/docs/docs-and-web-client/src/content/docs/getting-started/rust.mdx
+++ b/docs/docs-and-web-client/src/content/docs/getting-started/rust.mdx
@@ -47,33 +47,57 @@ fn main() {
 - `text: &(impl AsRef<str> + ?Sized)` — Text to transliterate
 - `from: Script` — Source script/language
 - `to: Script` — Target script/language  
-- `trans_options: Option<&HashMap<String, bool>>` — Optional custom transliteration options
+- `trans_options: Option<&CustomOptions>` — Optional custom transliteration options
 
 **Returns:** `Cow<'a, str>` — Transliterated text (borrows input when `from == to`)
 
 ### With Custom Transliteration Options
 
-You can pass custom options as the fourth argument to fine-tune transliteration behavior:
+The fourth argument accepts a [`CustomOptions`](https://docs.rs/lipilekhika/latest/lipilekhika/struct.CustomOptions.html) value. The recommended way to construct one is with [`CustomOptionsBuilder`](https://docs.rs/lipilekhika/latest/lipilekhika/struct.CustomOptionsBuilder.html): call `CustomOptionsBuilder::default()`, enable options with `<category>_<option>(bool)` setters (replace `:` in canonical keys with `_`), then `.build()`.
 
 ```rust
-use lipilekhika::{transliterate, Script};
-use std::collections::HashMap;
+use lipilekhika::{transliterate, CustomOptionsBuilder, Script};
 
 fn main() {
-    let mut options = HashMap::new();
-    options.insert(
-        "brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra".to_string(),
-        true
-    );
-    
+    let options = CustomOptionsBuilder::default()
+        .brahmic_to_brahmic_replace_pancham_varga_varna_with_anusvAra(true)
+        .build();
+
     let result = transliterate(
         "गङ्गा",
         Script::Devanagari,
         Script::Gujarati,
-        Some(&options)
+        Some(&options),
     );
-    
+
     println!("{}", result); // ગંગા (instead of ગઙ્ગા)
+}
+```
+
+<Aside type="tip">
+  `CustomOptions::default()` leaves every option disabled. Use `CustomOptions::all_enabled()` when you need all flags on.
+</Aside>
+
+### From or to a hash map
+
+If your configuration already lives in a map (for example from JSON or another language binding), convert with [`CustomOptions::try_from_map`](https://docs.rs/lipilekhika/latest/lipilekhika/struct.CustomOptions.html#method.try_from_map) and export with [`CustomOptions::to_options_map`](https://docs.rs/lipilekhika/latest/lipilekhika/struct.CustomOptions.html#method.to_options_map). Unknown keys return `UnknownCustomOptionKey`.
+
+```rust
+use lipilekhika::{transliterate, CustomOptions, Script};
+use std::collections::HashMap;
+
+fn main() {
+    let mut map = HashMap::new();
+    map.insert(
+        "brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra".to_string(),
+        true,
+    );
+
+    let options = CustomOptions::try_from_map(&map).unwrap();
+    let result = transliterate("गङ्गा", Script::Devanagari, Script::Gujarati, Some(&options));
+    println!("{}", result);
+
+    let exported: HashMap<String, bool> = options.to_options_map();
 }
 ```
 

--- a/docs/docs-and-web-client/src/content/docs/getting-started/rust.mdx
+++ b/docs/docs-and-web-client/src/content/docs/getting-started/rust.mdx
@@ -67,8 +67,8 @@ fn main() {
     );
     
     let result = transliterate(
-        "గంగా",
-        Script::Telugu,
+        "गङ्गा",
+        Script::Devanagari,
         Script::Gujarati,
         Some(&options)
     );

--- a/docs/docs-and-web-client/src/content/docs/getting-started/wasm.mdx
+++ b/docs/docs-and-web-client/src/content/docs/getting-started/wasm.mdx
@@ -17,7 +17,7 @@ Lipi Lekhika includes a blazing-fast 🦀 **Rust-based WebAssembly (WASM) module
 The WASM module offers several advantages over the pure JavaScript implementation:
 
 - **⚡ Superior Performance** — Rust's compiled WASM code executes significantly faster than JavaScript
-- **📦 Compact Size** — Only 117 KB gzipped (base64), including all script data embedded
+- **📦 Compact Size** — Only 114 KB gzipped (base64), including all script data embedded
 - **🌍 Universal Compatibility** — Works seamlessly in Node.js, browsers, Deno, Bun, and more
 - **🔒 Type Safety** — Built with Rust's type system for reliability
 - **🎯 Same API** — Drop-in replacement for the standard `transliterate` function
@@ -70,8 +70,8 @@ You can pass custom transliteration options just like the standard function:
 import { transliterate_wasm } from 'lipilekhika';
 
 const result = await transliterate_wasm(
-  'గంగా',
-  'Telugu',
+  'गङ्गा',
+  'Devanagari',
   'Gujarati',
   { 'brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra': true }
 );
@@ -210,7 +210,7 @@ console.log(result);
 
 ## Bundle Size
 
-The WASM module adds only **117 KB (gzipped base64)** to your bundle, which includes:
+The WASM module adds only **114 KB (gzipped base64)** to your bundle, which includes:
 - The compiled Rust WASM binary
 - All script data embedded (no external data files needed)
 - Complete transliteration logic

--- a/packages/dart/binding/src/api/main.rs
+++ b/packages/dart/binding/src/api/main.rs
@@ -52,8 +52,10 @@ pub fn transliterate(
 ) -> Result<String, String> {
     let from = parse_script("from_script", &from_script)?;
     let to = parse_script("to_script", &to_script)?;
-    let options: Option<lipilekhika::HashMap<String, bool>> =
-        options.map(|m| m.into_iter().collect());
+    let options = options
+        .map(lipilekhika::CustomOptions::try_from_map)
+        .transpose()
+        .map_err(|_| "options contains an unknown custom option key".to_string())?;
     Ok(lipilekhika::transliterate(&text, from, to, options.as_ref()).into_owned())
 }
 

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## js-lib@1.0.13
 
 - now the `transliterate`, `transliterate_wasm` and `transliterate_node` accept `string | string[]` for `text` input
-- Reduced wasm size to 244Kb (base64 gzipped :- 117 kb, gzipped :- 78), as now the `rust-lib` is `no_std` compatible
+- Reduced wasm size to 244Kb (base64 gzipped :- 114 kb, gzipped :- 76), as now the `rust-lib` is `no_std` compatible
 - The performance of the `napi-rs` and `wasm` bindings have improved
 
 ## js-lib@1.0.12

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## js-lib@1.0.13
 
 - now the `transliterate`, `transliterate_wasm` and `transliterate_node` accept `string | string[]` for `text` input
-- Reduced wasm size to 244Kb (base64 gzipped :- 114 kb, gzipped :- 76), as now the `rust-lib` is `no_std` compatible
+- Reduced wasm size to 244 KB (base64 gzipped: 114 KB, gzipped: 76 KB), as now the `rust-lib` is `no_std` compatible
 - The performance of the `napi-rs` and `wasm` bindings have improved
 
 ## js-lib@1.0.12

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -76,12 +76,12 @@ console.log(result); // ગંગા (instead of ગઙ્ગા)
 
 **Parameters:**
 
-- `text: string` — Text to transliterate
+- `text: string | string[]` — Text to transliterate (see `TransliterateInput`)
 - `from: ScriptLangType` — Source script/language
 - `to: ScriptLangType` — Target script/language
 - `options?: TransliterationOptions` — Custom transliteration options
 
-**Returns:** `Promise<string>`
+**Returns:** `Promise<TransliterateOutput<T>>` — `string` when `text` is a string, `string[]` when `text` is an array
 
 </details>
 
@@ -117,12 +117,12 @@ Read more about [WASM Module](https://lipilekhika.in/getting-started/wasm/)
 
 **Parameters:**
 
-- `text: string` — Text to transliterate
+- `text: string | string[]` — Text to transliterate (see `TransliterateInput`)
 - `from: ScriptLangType` — Source script/language
 - `to: ScriptLangType` — Target script/language
 - `options?: TransliterationOptions` — Custom transliteration options
 
-**Returns:** `Promise<string>`
+**Returns:** `Promise<TransliterateOutput<T>>` — `string` when `text` is a string, `string[]` when `text` is an array
 
 **Note:** Uses the fast Rust-based WASM implementation for improved performance. Works in all JavaScript environments (Node.js, browsers, Deno, Bun).
 
@@ -142,9 +142,9 @@ Read more about [WASM Module](https://lipilekhika.in/getting-started/wasm/)
 
 Available via `lipilekhika/node`. Uses a native Rust N-API binding for near-native performance. Only works in **Node.js, Bun, and Deno** on **Linux/macOS/Windows (x86_64 & aarch64)**.
 
-**Parameters:** Same as `transliterate`.
+**Parameters:** Same as `transliterate` (`text: string | string[]`, etc.).
 
-**Returns:** `Promise<string>`
+**Returns:** `Promise<TransliterateOutput<T>>` — `string` when `text` is a string, `string[]` when `text` is an array
 
 </details>
 
@@ -161,7 +161,12 @@ Available via `lipilekhika/node`.
 
 ```typescript
 import { SCRIPT_LIST, LANG_LIST, ALL_LANG_SCRIPT_LIST } from 'lipilekhika';
-import type { ScriptLangType, TransliterationOptions } from 'lipilekhika';
+import type {
+  ScriptLangType,
+  TransliterateInput,
+  TransliterateOutput,
+  TransliterationOptions
+} from 'lipilekhika';
 ```
 
 | Export                   | Description                                             |
@@ -170,6 +175,8 @@ import type { ScriptLangType, TransliterationOptions } from 'lipilekhika';
 | `LANG_LIST`              | Array of all supported language names mapped to scripts |
 | `ALL_LANG_SCRIPT_LIST`   | Combined list of all scripts and languages              |
 | `ScriptLangType`         | Type for script/language identifiers (includes aliases) |
+| `TransliterateInput`     | `string | readonly string[]` accepted by transliterate APIs |
+| `TransliterateOutput<T>` | Return type inferred from input (`string` or `string[]`) |
 | `TransliterationOptions` | Type for custom transliteration options                 |
 | `ScriptListType`         | Type for the script list                                |
 | `LangListType`           | Type for the language list                              |

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -59,7 +59,7 @@ console.log(result); // न जायते म्रियते वा
 ```typescript
 import { transliterate } from 'lipilekhika';
 
-const result = await transliterate('గంగా', 'Devanagari', 'Gujarati', {
+const result = await transliterate('गङ्गा', 'Devanagari', 'Gujarati', {
   'brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra': true
 });
 console.log(result); // ગંગા (instead of ગઙ્ગા)
@@ -76,12 +76,12 @@ console.log(result); // ગંગા (instead of ગઙ્ગા)
 
 **Parameters:**
 
-- `text: string | string[]` — Text to transliterate (one string or many; same options for all)
+- `text: string` — Text to transliterate
 - `from: ScriptLangType` — Source script/language
 - `to: ScriptLangType` — Target script/language
 - `options?: TransliterationOptions` — Custom transliteration options
 
-**Returns:** `Promise<string | string[]>` — matches the shape of `text`
+**Returns:** `Promise<string>`
 
 </details>
 
@@ -117,12 +117,12 @@ Read more about [WASM Module](https://lipilekhika.in/getting-started/wasm/)
 
 **Parameters:**
 
-- `text: string | string[]` — Same as `transliterate`
+- `text: string` — Text to transliterate
 - `from: ScriptLangType` — Source script/language
 - `to: ScriptLangType` — Target script/language
 - `options?: TransliterationOptions` — Custom transliteration options
 
-**Returns:** `Promise<string | string[]>`
+**Returns:** `Promise<string>`
 
 **Note:** Uses the fast Rust-based WASM implementation for improved performance. Works in all JavaScript environments (Node.js, browsers, Deno, Bun).
 
@@ -142,9 +142,9 @@ Read more about [WASM Module](https://lipilekhika.in/getting-started/wasm/)
 
 Available via `lipilekhika/node`. Uses a native Rust N-API binding for near-native performance. Only works in **Node.js, Bun, and Deno** on **Linux/macOS/Windows (x86_64 & aarch64)**.
 
-**Parameters:** Same as `transliterate` (including `text: string | string[]`).
+**Parameters:** Same as `transliterate`.
 
-**Returns:** `Promise<string | string[]>`
+**Returns:** `Promise<string>`
 
 </details>
 

--- a/packages/js/binding/src/lib.rs
+++ b/packages/js/binding/src/lib.rs
@@ -42,8 +42,10 @@ pub fn transliterate(
     let to_script = Script::from_str(to.trim())
         .map_err(|e| Error::from_reason(format!("invalid to script: {e}")))?;
 
-    let trans_options: Option<lipilekhika::HashMap<String, bool>> =
-        trans_options.map(|m| m.into_iter().collect());
+    let trans_options = trans_options
+        .map(lipilekhika::CustomOptions::try_from_map)
+        .transpose()
+        .map_err(|_| Error::from_reason("trans_options contains an unknown option key"))?;
 
     Ok(
         lipilekhika::transliterate(&text, from_script, to_script, trans_options.as_ref())

--- a/packages/js/tests/check_binding.test.ts
+++ b/packages/js/tests/check_binding.test.ts
@@ -142,4 +142,21 @@ describe('wasm binding smoke check', () => {
       }
     );
   });
+
+  describe('transliterate works with custom options', () => {
+    it('returns an array of results for $from -> $to', async () => {
+      {
+        const result = await transliterate_node('गङ्गा', 'Devanagari', 'Gujarati', {
+          'brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra': true
+        });
+        expect(result).toBe('ગંગા');
+      }
+      {
+        const result = await transliterate_wasm('गङ्गा', 'Devanagari', 'Gujarati', {
+          'brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra': true
+        });
+        expect(result).toBe('ગંગા');
+      }
+    });
+  });
 });

--- a/packages/js/tests/check_binding.test.ts
+++ b/packages/js/tests/check_binding.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { transliterate_node, createTypingContext } from '../src/node';
 import { transliterate, transliterate_wasm } from '../src/index';
+import { transliterate as transliterate_wasm_bind } from '../wasm/bind';
+
+const PACHAM_VARGA_AS_ANUSVARA = {
+  'brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra': true
+} as const;
 
 const EXAMPLES = {
   transliterate: [
@@ -59,6 +64,13 @@ const EXAMPLES = {
     '🙏🏽',
     'mixed: 🕉️ 𑀕 गङ्गा abc'
   ],
+  wasmBoundaryWithEmpty: ['', 'गङ्गा', '', '𑀕𑀗𑁆𑀕𑀸', '👨‍👩‍👧‍👦', '', 'mixed: 🕉️ 𑀕 गङ्गा abc', ''],
+  batchTransliterateWithOptions: {
+    texts: ['गङ्गा', '', 'गङ्गा 🎉'],
+    from: 'Devanagari',
+    to: 'Gujarati',
+    outputs: ['ગંગા', '', 'ગંગા 🎉']
+  },
   emulateTyping: [
     {
       script: 'Devanagari',
@@ -117,9 +129,15 @@ describe('wasm binding smoke check', () => {
     }
   });
 
-  it('preserves mixed-width strings through the WASM FFI boundary', async () => {
+  it('preserves mixed-width strings through the direct WASM FFI boundary', async () => {
     const texts = [...EXAMPLES.wasmBoundary];
-    const out = await transliterate_wasm(texts, 'Devanagari', 'Devanagari');
+    const out = await transliterate_wasm_bind(texts, 'Devanagari', 'Devanagari');
+    expect(out).toEqual(texts);
+  });
+
+  it('preserves empty and mixed-width strings through the direct WASM FFI boundary', async () => {
+    const texts = [...EXAMPLES.wasmBoundaryWithEmpty];
+    const out = await transliterate_wasm_bind(texts, 'Devanagari', 'Devanagari');
     expect(out).toEqual(texts);
   });
 
@@ -146,17 +164,29 @@ describe('wasm binding smoke check', () => {
   describe('transliterate works with custom options', () => {
     it('returns an array of results for $from -> $to', async () => {
       {
-        const result = await transliterate_node('गङ्गा', 'Devanagari', 'Gujarati', {
-          'brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra': true
-        });
+        const result = await transliterate_node(
+          'गङ्गा',
+          'Devanagari',
+          'Gujarati',
+          PACHAM_VARGA_AS_ANUSVARA
+        );
         expect(result).toBe('ગંગા');
       }
       {
-        const result = await transliterate_wasm('गङ्गा', 'Devanagari', 'Gujarati', {
-          'brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra': true
-        });
+        const result = await transliterate_wasm(
+          'गङ्गा',
+          'Devanagari',
+          'Gujarati',
+          PACHAM_VARGA_AS_ANUSVARA
+        );
         expect(result).toBe('ગંગા');
       }
+    });
+
+    it('supports array transliteration with custom options in the WASM bulk path', async () => {
+      const { texts, from, to, outputs } = EXAMPLES.batchTransliterateWithOptions;
+      const result = await transliterate_wasm(texts, from, to, PACHAM_VARGA_AS_ANUSVARA);
+      expect(result).toEqual(outputs);
     });
   });
 });

--- a/packages/js/wasm/src/lib.rs
+++ b/packages/js/wasm/src/lib.rs
@@ -1,16 +1,17 @@
-use lipilekhika::HashMap;
+use lipilekhika::CustomOptions;
 use lipilekhika::scripts::Script;
 use wasm_bindgen::prelude::*;
 
 fn parse_trans_options(
     trans_options: Option<js_sys::Object>,
-) -> Result<Option<HashMap<String, bool>>, JsError> {
+) -> Result<Option<CustomOptions>, JsError> {
     let Some(obj) = trans_options else {
         return Ok(None);
     };
 
     let entries = js_sys::Object::entries(&obj);
-    let mut map = HashMap::with_capacity(entries.length() as usize);
+    let mut options = CustomOptions::default();
+    let mut saw_any = false;
 
     for i in 0..entries.length() {
         let entry = js_sys::Array::from(&entries.get(i));
@@ -22,13 +23,16 @@ fn parse_trans_options(
             .get(1)
             .as_bool()
             .ok_or_else(|| JsError::new("trans_options value must be a boolean"))?;
-        map.insert(key, value);
+        options
+            .try_set(&key, value)
+            .map_err(|_| JsError::new(&format!("unknown trans_options key: {key}")))?;
+        saw_any = true;
     }
 
-    if map.is_empty() {
+    if !saw_any {
         Ok(None)
     } else {
-        Ok(Some(map))
+        Ok(Some(options))
     }
 }
 
@@ -36,7 +40,7 @@ fn transliterate_by_id(
     text: &str,
     from_id: u8,
     to_id: u8,
-    trans_options: Option<&HashMap<String, bool>>,
+    trans_options: Option<&CustomOptions>,
 ) -> Result<String, JsError> {
     let from = Script::from_id(from_id).ok_or_else(|| JsError::new("invalid source script id"))?;
     let to = Script::from_id(to_id).ok_or_else(|| JsError::new("invalid target script id"))?;
@@ -77,7 +81,7 @@ fn transliterate_many_by_id(
     offsets: &[u32],
     from_id: u8,
     to_id: u8,
-    trans_options: Option<&HashMap<String, bool>>,
+    trans_options: Option<&CustomOptions>,
 ) -> Result<Vec<String>, JsError> {
     if from_id == to_id {
         return Ok(slices_from_joined(joined, offsets)?

--- a/packages/js/wasm/src/lib.rs
+++ b/packages/js/wasm/src/lib.rs
@@ -52,7 +52,9 @@ fn piece_at<'a>(joined: &'a str, offsets: &[u32], index: usize) -> Result<&'a st
     let start = offsets[index * 2] as usize;
     let end = offsets[index * 2 + 1] as usize;
     if !joined.is_char_boundary(start) {
-        return Err(JsError::new("text offset start is not a UTF-8 char boundary"));
+        return Err(JsError::new(
+            "text offset start is not a UTF-8 char boundary",
+        ));
     }
     if !joined.is_char_boundary(end) {
         return Err(JsError::new("text offset end is not a UTF-8 char boundary"));

--- a/packages/python/binding/src/lib.rs
+++ b/packages/python/binding/src/lib.rs
@@ -1,4 +1,3 @@
-use lipilekhika::HashMap;
 use lipilekhika::ScriptListEnum;
 use lipilekhika::scripts::Script;
 use pyo3::prelude::*;
@@ -22,15 +21,21 @@ fn transliterate(
     to_script: &str,
     trans_options: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<String> {
-    let options: Option<HashMap<String, bool>> = trans_options.map(|dict| {
-        dict.iter()
-            .filter_map(|(k, v)| {
-                let key = k.extract::<String>().ok()?;
-                let value = v.extract::<bool>().ok()?;
-                Some((key, value))
-            })
-            .collect()
-    });
+    let options = trans_options
+        .map(|dict| -> PyResult<lipilekhika::CustomOptions> {
+            let mut options = lipilekhika::CustomOptions::default();
+            for (k, v) in dict.iter() {
+                let key = k.extract::<String>()?;
+                let value = v.extract::<bool>()?;
+                options.try_set(&key, value).map_err(|_| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "unknown trans_options key {key:?}"
+                    ))
+                })?;
+            }
+            Ok(options)
+        })
+        .transpose()?;
 
     let from = py_parse_script(from_script, "from_script")?;
     let to = py_parse_script(to_script, "to_script")?;

--- a/packages/rust/CHANGELOG.md
+++ b/packages/rust/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Now the `typing` module has `std` feature which can be enabled to have automatic context clear logic.
 - Now 9x faster over the JS version (previosuly 7x, ~63ms -> ~51ms)
 - The wasm build is also smaller (as no `std` bloat)
+- **Major Change** :- Now Custom Options are accepted via a struct (CustomOptions) instead of of a HashMap.
 
 ## rust-lib@1.1.0
 

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -15,6 +15,7 @@ include = [
     "src/**/*",
     "build.rs",
     "scripts_rs_builder.rs",
+    "custom_options_rs_builder.rs",
     "Cargo.toml",
     "LICENSE*",
     "README*",
@@ -42,6 +43,7 @@ once_cell = { version = "1.21", default-features = false, features = [
     "race",
 ] }
 strum = { version = "0.28.0", default-features = false, features = ["derive"] }
+derive_builder = { version = "0.20.2", default-features = false, features = ["alloc"] }
 
 [features]
 default = []

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -64,8 +64,8 @@ fn main() {
     );
     
     let result = transliterate(
-        "గంగా",
-        Script::Telugu,
+        "गङ्गा",
+        Script::Devanagari,
         Script::Gujarati,
         Some(&options)
     );

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -52,24 +52,23 @@ fn main() {
 
 ### With Custom Options
 
+Pass a [`CustomOptions`](https://docs.rs/lipilekhika/latest/lipilekhika/struct.CustomOptions.html) value as the fourth argument. The recommended way to build one is with [`CustomOptionsBuilder`](https://docs.rs/lipilekhika/latest/lipilekhika/struct.CustomOptionsBuilder.html):
+
 ```rust
-use lipilekhika::{transliterate, Script};
-use std::collections::HashMap;
+use lipilekhika::{transliterate, CustomOptionsBuilder, Script};
 
 fn main() {
-    let mut options = HashMap::new();
-    options.insert(
-        "brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra".to_string(),
-        true
-    );
-    
+    let options = CustomOptionsBuilder::default()
+        .brahmic_to_brahmic_replace_pancham_varga_varna_with_anusvAra(true)
+        .build();
+
     let result = transliterate(
         "गङ्गा",
         Script::Devanagari,
         Script::Gujarati,
-        Some(&options)
+        Some(&options),
     );
-    
+
     println!("{}", result); // ગંગા (instead of ગઙ્ગા)
 }
 ```
@@ -128,7 +127,7 @@ pub fn transliterate<'a>(
     text: &'a (impl AsRef<str> + ?Sized),
     from: Script,
     to: Script,
-    trans_options: Option<&HashMap<String, bool>>,
+    trans_options: Option<&CustomOptions>,
 ) -> Cow<'a, str>
 ```
 
@@ -138,7 +137,7 @@ Transliterates text from one script to another.
 - `text` — Text to transliterate
 - `from` — Source script (`Script` enum)
 - `to` — Target script (`Script` enum)
-- `trans_options` — Optional custom transliteration options
+- `trans_options` — Optional [`CustomOptions`] (use [`CustomOptionsBuilder`] to construct)
 
 **Returns:** `Cow<'a, str>` — Transliterated text (borrows input when `from == to`)
 
@@ -236,6 +235,8 @@ Devanagari, Bengali, Tamil, Telugu, Kannada, Malayalam, Gujarati, Odia, Gurmukhi
 📖 Full list: [lipilekhika.in/reference/supported_scripts](https://lipilekhika.in/reference/supported_scripts)
 
 ## 🔧 Custom Options
+
+Build a [`CustomOptions`] with [`CustomOptionsBuilder::default`] and `<category>_<option>(bool)` setters (replace `:` in option keys with `_`). For map-based sources, use [`CustomOptions::try_from_map`] to parse and [`CustomOptions::to_options_map`] to export.
 
 See the full list of custom transliteration options:
 

--- a/packages/rust/build.rs
+++ b/packages/rust/build.rs
@@ -12,12 +12,14 @@ mod schema {
     include!("src/script_data/schema.rs");
 }
 
+mod custom_options_rs_builder;
 mod scripts_rs_builder;
 
 use schema::{
     CustomOptionMap, CustomOptionMapJson, ScriptData, ScriptDataJson, ScriptListData,
     ScriptListDataJson,
 };
+use custom_options_rs_builder::render_custom_options_rs;
 use scripts_rs_builder::render_scripts_rs;
 
 fn read_json_file(path: &Path) -> String {
@@ -33,6 +35,7 @@ fn main() {
     println!("cargo:rerun-if-changed={}", script_list_path.display());
     println!("cargo:rerun-if-changed={}", custom_options_path.display());
     println!("cargo:rerun-if-changed=scripts_rs_builder.rs");
+    println!("cargo:rerun-if-changed=custom_options_rs_builder.rs");
 
     let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR missing"));
 
@@ -92,10 +95,11 @@ fn main() {
     fs::write(&scripts_rs_path, scripts_rs)
         .unwrap_or_else(|e| panic!("Failed to write {}: {}", scripts_rs_path.display(), e));
 
-    // 3) custom_options.json -> custom_options.bin
+    // 3) custom_options.json -> custom_options.bin + src/custom_options.rs
     let custom_options_json = read_json_file(custom_options_path);
     let custom_options_raw: CustomOptionMapJson = serde_json::from_str(&custom_options_json)
         .unwrap_or_else(|e| panic!("{}: {}", custom_options_path.display(), e));
+    let custom_options_rs = render_custom_options_rs(&custom_options_raw);
     let custom_options_map: CustomOptionMap = custom_options_raw
         .into_iter()
         .map(|(k, v)| (k, v.into()))
@@ -108,6 +112,15 @@ fn main() {
         panic!(
             "Failed to write {}: {}",
             custom_options_bin_path.display(),
+            e
+        )
+    });
+
+    let custom_options_rs_path = manifest_dir.join("src/custom_options.rs");
+    fs::write(&custom_options_rs_path, custom_options_rs).unwrap_or_else(|e| {
+        panic!(
+            "Failed to write {}: {}",
+            custom_options_rs_path.display(),
             e
         )
     });

--- a/packages/rust/build.rs
+++ b/packages/rust/build.rs
@@ -15,11 +15,11 @@ mod schema {
 mod custom_options_rs_builder;
 mod scripts_rs_builder;
 
+use custom_options_rs_builder::render_custom_options_rs;
 use schema::{
     CustomOptionMap, CustomOptionMapJson, ScriptData, ScriptDataJson, ScriptListData,
     ScriptListDataJson,
 };
-use custom_options_rs_builder::render_custom_options_rs;
 use scripts_rs_builder::render_scripts_rs;
 
 fn read_json_file(path: &Path) -> String {

--- a/packages/rust/custom_options_rs_builder.rs
+++ b/packages/rust/custom_options_rs_builder.rs
@@ -1,4 +1,5 @@
 use quote::{format_ident, quote};
+use syn::Index;
 
 use crate::schema::CustomOptionMapJson;
 
@@ -12,6 +13,9 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
         })
         .collect();
 
+    let entry_count = fields.len();
+    let entry_count_lit = Index::from(entry_count);
+
     let struct_fields = fields.iter().map(|(field_ident, raw_key)| {
         let doc = format!("`{raw_key}`");
         quote! {
@@ -19,6 +23,17 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
             pub #field_ident: bool,
         }
     });
+
+    let option_keys = fields.iter().map(|(_, raw_key)| quote! { #raw_key, });
+
+    let entry_tuples: Vec<_> = fields
+        .iter()
+        .map(|(field_ident, raw_key)| {
+            quote! {
+                (#raw_key, self.#field_ident),
+            }
+        })
+        .collect();
 
     let try_set_arms = fields.iter().map(|(field_ident, raw_key)| {
         quote! {
@@ -29,14 +44,17 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
         }
     });
 
+    let get_arms = fields.iter().map(|(field_ident, raw_key)| {
+        quote! {
+            #raw_key => Ok(self.#field_ident),
+        }
+    });
+
     let tokens = quote! {
         // generated file, do not edit
         #[rustfmt::skip]
+        use alloc::string::{String, ToString};
         use derive_builder::Builder;
-
-        /// Returned when [`CustomOptions::try_set`] is called with an unknown option key.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        pub struct UnknownCustomOptionKey;
 
         /// Custom transliteration options struct
         ///
@@ -51,7 +69,17 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
             #(#struct_fields)*
         }
 
+        /// Returned when [`CustomOptions::try_set`] or [`CustomOptions::get`] is called with an unknown option key.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub struct UnknownCustomOptionKey;
+
         impl CustomOptions {
+            /// Number of supported custom options.
+            pub const ENTRY_COUNT: usize = #entry_count_lit;
+
+            /// Canonical keys in `custom_options.json` insertion order.
+            pub const KEYS: &'static [&'static str] = &[#(#option_keys)*];
+
             /// Sets an option by its canonical `category:option` key.
             #[inline]
             pub fn try_set(
@@ -63,6 +91,34 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
                     #(#try_set_arms)*
                     _ => Err(UnknownCustomOptionKey),
                 }
+            }
+
+            /// Reads an option by its canonical `category:option` key.
+            #[inline]
+            pub fn get(&self, key: &str) -> Result<bool, UnknownCustomOptionKey> {
+                match key {
+                    #(#get_arms)*
+                    _ => Err(UnknownCustomOptionKey),
+                }
+            }
+
+            /// Fixed-size array of canonical key/value pairs (`&opts.as_entries()` for a slice).
+            #[inline]
+            pub fn as_entries(&self) -> [(&'static str, bool); Self::ENTRY_COUNT] {
+                [#(#entry_tuples)*]
+            }
+
+            /// Builds a hash map from canonical option keys (supports any `FromIterator<(String, bool)>` map, e.g. hashbrown or std).
+            #[inline]
+            pub fn to_options_map<M>(&self) -> M
+            where
+                M: FromIterator<(String, bool)>,
+            {
+                self.as_entries()
+                    .iter()
+                    .copied()
+                    .map(|(key, enabled)| (key.to_string(), enabled))
+                    .collect()
             }
         }
 

--- a/packages/rust/custom_options_rs_builder.rs
+++ b/packages/rust/custom_options_rs_builder.rs
@@ -96,6 +96,7 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
 
             /// Sets an option by its canonical `category:option` key.
             #[inline]
+            #[rustfmt::skip]
             pub fn try_set(&mut self, key: &str, value: bool) -> Result<(), UnknownCustomOptionKey> {
                 match key {
                     #(#try_set_arms)*
@@ -114,6 +115,7 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
 
             /// Fixed-size array of canonical key/value pairs (`&opts.as_entries()` for a slice).
             #[inline]
+            #[rustfmt::skip]
             pub fn as_entries(&self) -> [(&'static str, bool); Self::ENTRY_COUNT] {
                 [#(#entry_tuples)*]
             }

--- a/packages/rust/custom_options_rs_builder.rs
+++ b/packages/rust/custom_options_rs_builder.rs
@@ -50,6 +50,12 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
         }
     });
 
+    let all_enabled_fields = fields.iter().map(|(field_ident, _)| {
+        quote! {
+            #field_ident: true,
+        }
+    });
+
     let tokens = quote! {
         // generated file, do not edit
         #[rustfmt::skip]
@@ -79,6 +85,14 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
 
             /// Canonical keys in `custom_options.json` insertion order.
             pub const KEYS: &'static [&'static str] = &[#(#option_keys)*];
+
+            /// Every option enabled (no runtime key lookup).
+            #[inline]
+            pub const fn all_enabled() -> Self {
+                Self {
+                    #(#all_enabled_fields)*
+                }
+            }
 
             /// Sets an option by its canonical `category:option` key.
             #[inline]
@@ -119,6 +133,45 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
                     .copied()
                     .map(|(key, enabled)| (key.to_string(), enabled))
                     .collect()
+            }
+            /// Builds [`CustomOptions`] from any map-like `(key, enabled)` source.
+            ///
+            /// Accepts [`hashbrown::HashMap`](hashbrown::HashMap), [`std::collections::HashMap`](std::collections::HashMap),
+            /// iterators of pairs, and other collections via [`IntoIterator`].
+            pub fn try_from_map<M, K, V>(map: M) -> Result<Self, UnknownCustomOptionKey>
+            where
+                M: IntoIterator<Item = (K, V)>,
+                K: AsRef<str>,
+                V: core::borrow::Borrow<bool>,
+            {
+                let mut options = Self::default();
+                for (key, enabled) in map {
+                    options.try_set(key.as_ref(), *enabled.borrow())?;
+                }
+                Ok(options)
+            }
+
+            /// Builds [`CustomOptions`] from a list of `(key, enabled)` pairs.
+            #[inline]
+            pub fn try_from_pairs<I, S>(pairs: I) -> Result<Self, UnknownCustomOptionKey>
+            where
+                I: IntoIterator<Item = (S, bool)>,
+                S: AsRef<str>,
+            {
+                Self::try_from_map(pairs)
+            }
+
+            /// Builds [`CustomOptions`] from an optional map-like source.
+            #[inline]
+            pub fn try_from_optional_map<M, K, V>(
+                map: Option<M>,
+            ) -> Result<Option<Self>, UnknownCustomOptionKey>
+            where
+                M: IntoIterator<Item = (K, V)>,
+                K: AsRef<str>,
+                V: core::borrow::Borrow<bool>,
+            {
+                map.map(Self::try_from_map).transpose()
             }
         }
 

--- a/packages/rust/custom_options_rs_builder.rs
+++ b/packages/rust/custom_options_rs_builder.rs
@@ -96,11 +96,7 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
 
             /// Sets an option by its canonical `category:option` key.
             #[inline]
-            pub fn try_set(
-                &mut self,
-                key: &str,
-                value: bool,
-            ) -> Result<(), UnknownCustomOptionKey> {
+            pub fn try_set(&mut self, key: &str, value: bool) -> Result<(), UnknownCustomOptionKey> {
                 match key {
                     #(#try_set_arms)*
                     _ => Err(UnknownCustomOptionKey),

--- a/packages/rust/custom_options_rs_builder.rs
+++ b/packages/rust/custom_options_rs_builder.rs
@@ -12,9 +12,20 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
         })
         .collect();
 
-    let struct_fields = fields.iter().map(|(field_ident, _)| {
+    let struct_fields = fields.iter().map(|(field_ident, raw_key)| {
+        let doc = format!("`{raw_key}`");
         quote! {
+            #[doc = #doc]
             pub #field_ident: bool,
+        }
+    });
+
+    let try_set_arms = fields.iter().map(|(field_ident, raw_key)| {
+        quote! {
+            #raw_key => {
+                self.#field_ident = value;
+                Ok(())
+            }
         }
     });
 
@@ -23,17 +34,36 @@ pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String 
         #[rustfmt::skip]
         use derive_builder::Builder;
 
-        /// Enabled/disabled flags for each transliteration custom option key
+        /// Returned when [`CustomOptions::try_set`] is called with an unknown option key.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub struct UnknownCustomOptionKey;
+
+        /// Custom transliteration options struct
         ///
         /// Use [`CustomOptionsBuilder::default`] and `<category>_<option>(bool)` setters, or
         /// [`CustomOptions::default`] for all options disabled.
         ///
-        /// for list of supported options you can visit [Custom Options](https://lipilekhika.in/reference/custom_trans_options/)
+        /// For a list of supported options visit [Custom Options](https://lipilekhika.in/reference/custom_trans_options/).
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Builder)]
         #[builder(no_std, default, pattern = "owned", build_fn(name = "try_build"))]
         #[allow(non_snake_case)]
         pub struct CustomOptions {
             #(#struct_fields)*
+        }
+
+        impl CustomOptions {
+            /// Sets an option by its canonical `category:option` key.
+            #[inline]
+            pub fn try_set(
+                &mut self,
+                key: &str,
+                value: bool,
+            ) -> Result<(), UnknownCustomOptionKey> {
+                match key {
+                    #(#try_set_arms)*
+                    _ => Err(UnknownCustomOptionKey),
+                }
+            }
         }
 
         impl CustomOptionsBuilder {

--- a/packages/rust/custom_options_rs_builder.rs
+++ b/packages/rust/custom_options_rs_builder.rs
@@ -1,0 +1,51 @@
+use quote::{format_ident, quote};
+
+use crate::schema::CustomOptionMapJson;
+
+/// Generate the contents of `src/custom_options.rs` from parsed `custom_options.json`.
+pub fn render_custom_options_rs(custom_options: &CustomOptionMapJson) -> String {
+    let fields: Vec<_> = custom_options
+        .keys()
+        .map(|key| {
+            let ident = format_ident!("{}", key.replace(':', "_"));
+            (ident, key.as_str())
+        })
+        .collect();
+
+    let struct_fields = fields.iter().map(|(field_ident, _)| {
+        quote! {
+            pub #field_ident: bool,
+        }
+    });
+
+    let tokens = quote! {
+        // generated file, do not edit
+        #[rustfmt::skip]
+        use derive_builder::Builder;
+
+        /// Enabled/disabled flags for each transliteration custom option key
+        ///
+        /// Use [`CustomOptionsBuilder::default`] and `<category>_<option>(bool)` setters, or
+        /// [`CustomOptions::default`] for all options disabled.
+        ///
+        /// for list of supported options you can visit [Custom Options](https://lipilekhika.in/reference/custom_trans_options/)
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Builder)]
+        #[builder(no_std, default, pattern = "owned", build_fn(name = "try_build"))]
+        #[allow(non_snake_case)]
+        pub struct CustomOptions {
+            #(#struct_fields)*
+        }
+
+        impl CustomOptionsBuilder {
+            /// Infallible build: every field has a `bool` default via [`Default`].
+            #[inline]
+            pub fn build(self) -> CustomOptions {
+                self.try_build()
+                    .expect("CustomOptionsBuilder: infallible with `#[builder(default)]`")
+            }
+        }
+    };
+
+    let syntax_tree: syn::File = syn::parse2(tokens).expect("Generated invalid Rust syntax");
+    prettyplease::unparse(&syntax_tree)
+}

--- a/packages/rust/examples/bench.rs
+++ b/packages/rust/examples/bench.rs
@@ -6,6 +6,7 @@
 
 use hashbrown::HashMap;
 use indexmap::IndexMap;
+use lipilekhika::CustomOptions;
 use lipilekhika::get_script_list_data;
 use lipilekhika::preload_script_data;
 use lipilekhika::scripts::Script;
@@ -136,6 +137,13 @@ fn build_typing_options(opts: &Option<TypingOptionsYaml>) -> Option<TypingContex
     }
 
     Some(rust_opts)
+}
+
+fn options_from_map(map: Option<&HashMap<String, bool>>) -> Option<CustomOptions> {
+    map.map(|options| {
+        CustomOptions::try_from_map(options)
+            .expect("benchmark example options must use canonical keys")
+    })
 }
 
 // ----------------------------
@@ -328,7 +336,7 @@ fn measure_individual_transliteration(test_data: &[TransliterationTestCase]) -> 
             &td.input,
             parse_script(&td.from),
             parse_script(&td.to),
-            td.options.as_ref(),
+            options_from_map(td.options.as_ref()).as_ref(),
         );
     }
     start.elapsed().as_secs_f64() * 1000.0

--- a/packages/rust/examples/bench.rs
+++ b/packages/rust/examples/bench.rs
@@ -87,6 +87,8 @@ struct TransliterationTestCase {
     input: String,
     #[serde(default)]
     options: Option<HashMap<String, bool>>,
+    #[serde(skip)]
+    parsed_options: Option<CustomOptions>,
     #[serde(default)]
     #[allow(dead_code)]
     todo: Option<bool>,
@@ -222,6 +224,9 @@ fn get_test_data() -> Vec<TransliterationTestCase> {
             .unwrap_or_else(|e| panic!("Failed reading `{}`: {e}", file.display()));
         let mut cases: Vec<TransliterationTestCase> = yaml::from_str(&s)
             .unwrap_or_else(|e| panic!("Failed parsing `{}`: {e}", file.display()));
+        for case in &mut cases {
+            case.parsed_options = options_from_map(case.options.as_ref());
+        }
         data.append(&mut cases);
     }
     data
@@ -336,7 +341,7 @@ fn measure_individual_transliteration(test_data: &[TransliterationTestCase]) -> 
             &td.input,
             parse_script(&td.from),
             parse_script(&td.to),
-            options_from_map(td.options.as_ref()).as_ref(),
+            td.parsed_options.as_ref(),
         );
     }
     start.elapsed().as_secs_f64() * 1000.0

--- a/packages/rust/src/benches/benchmark.rs
+++ b/packages/rust/src/benches/benchmark.rs
@@ -81,6 +81,8 @@ struct TransliterationTestCase {
     input: String,
     #[serde(default)]
     options: Option<HashMap<String, bool>>,
+    #[serde(skip)]
+    parsed_options: Option<CustomOptions>,
     #[serde(default)]
     todo: Option<bool>,
 }
@@ -132,6 +134,13 @@ fn build_typing_options(opts: &Option<TypingOptionsYaml>) -> Option<TypingContex
     }
 
     Some(rust_opts)
+}
+
+fn options_from_map(map: Option<&HashMap<String, bool>>) -> Option<CustomOptions> {
+    map.map(|options| {
+        CustomOptions::try_from_map(options)
+            .expect("benchmark fixture options must use canonical keys")
+    })
 }
 
 // ----------------------------
@@ -212,6 +221,9 @@ fn load_transliteration_cases() -> Vec<TransliterationTestCase> {
             .unwrap_or_else(|e| panic!("Failed reading `{}`: {e}", file.display()));
         let mut cases: Vec<TransliterationTestCase> = yaml::from_str(&yaml_text)
             .unwrap_or_else(|e| panic!("Failed parsing `{}`: {e}", file.display()));
+        for case in &mut cases {
+            case.parsed_options = options_from_map(case.options.as_ref());
+        }
         all.append(&mut cases);
     }
     all
@@ -269,12 +281,7 @@ fn run_transliteration_pass(cases: &[TransliterationTestCase]) {
             &case.input,
             Script::from_str(&case.from).unwrap(),
             Script::from_str(&case.to).unwrap(),
-            case.options
-                .as_ref()
-                .map(CustomOptions::try_from_map)
-                .transpose()
-                .unwrap()
-                .as_ref(),
+            case.parsed_options.as_ref(),
         );
         black_box(out);
     }
@@ -299,12 +306,7 @@ fn run_transliteration_multi_pass(cases: &[TransliterationTestCase]) {
                         &case.input,
                         Script::from_str(&case.from).unwrap(),
                         Script::from_str(&case.to).unwrap(),
-                        case.options
-                            .as_ref()
-                            .map(CustomOptions::try_from_map)
-                            .transpose()
-                            .unwrap()
-                            .as_ref(),
+                        case.parsed_options.as_ref(),
                     );
                     black_box(out);
                 }

--- a/packages/rust/src/benches/benchmark.rs
+++ b/packages/rust/src/benches/benchmark.rs
@@ -1,5 +1,6 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use hashbrown::HashMap;
+use lipilekhika::CustomOptions;
 use lipilekhika::scripts::Script;
 use lipilekhika::transliterate;
 use lipilekhika::typing::{TypingContextOptions, emulate_typing};
@@ -268,7 +269,12 @@ fn run_transliteration_pass(cases: &[TransliterationTestCase]) {
             &case.input,
             Script::from_str(&case.from).unwrap(),
             Script::from_str(&case.to).unwrap(),
-            case.options.as_ref(),
+            case.options
+                .as_ref()
+                .map(CustomOptions::try_from_map)
+                .transpose()
+                .unwrap()
+                .as_ref(),
         );
         black_box(out);
     }
@@ -293,7 +299,12 @@ fn run_transliteration_multi_pass(cases: &[TransliterationTestCase]) {
                         &case.input,
                         Script::from_str(&case.from).unwrap(),
                         Script::from_str(&case.to).unwrap(),
-                        case.options.as_ref(),
+                        case.options
+                            .as_ref()
+                            .map(CustomOptions::try_from_map)
+                            .transpose()
+                            .unwrap()
+                            .as_ref(),
                     );
                     black_box(out);
                 }

--- a/packages/rust/src/custom_options.rs
+++ b/packages/rust/src/custom_options.rs
@@ -1,8 +1,6 @@
 #[rustfmt::skip]
+use alloc::string::{String, ToString};
 use derive_builder::Builder;
-/// Returned when [`CustomOptions::try_set`] is called with an unknown option key.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct UnknownCustomOptionKey;
 /// Custom transliteration options struct
 ///
 /// Use [`CustomOptionsBuilder::default`] and `<category>_<option>(bool)` setters, or
@@ -28,7 +26,22 @@ pub struct CustomOptions {
     ///`all_to_normal:preserve_specific_chars`
     pub all_to_normal_preserve_specific_chars: bool,
 }
+/// Returned when [`CustomOptions::try_set`] or [`CustomOptions::get`] is called with an unknown option key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownCustomOptionKey;
 impl CustomOptions {
+    /// Number of supported custom options.
+    pub const ENTRY_COUNT: usize = 7;
+    /// Canonical keys in `custom_options.json` insertion order.
+    pub const KEYS: &'static [&'static str] = &[
+        "all_to_normal:replace_pancham_varga_varna_with_n",
+        "brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra",
+        "all_to_sinhala:use_conjunct_enabling_halant",
+        "all_to_normal:remove_virAma_and_double_virAma",
+        "all_to_normal:replace_avagraha_with_a",
+        "normal_to_all:use_typing_chars",
+        "all_to_normal:preserve_specific_chars",
+    ];
     /// Sets an option by its canonical `category:option` key.
     #[inline]
     pub fn try_set(
@@ -67,6 +80,75 @@ impl CustomOptions {
             }
             _ => Err(UnknownCustomOptionKey),
         }
+    }
+    /// Reads an option by its canonical `category:option` key.
+    #[inline]
+    pub fn get(&self, key: &str) -> Result<bool, UnknownCustomOptionKey> {
+        match key {
+            "all_to_normal:replace_pancham_varga_varna_with_n" => {
+                Ok(self.all_to_normal_replace_pancham_varga_varna_with_n)
+            }
+            "brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra" => {
+                Ok(self.brahmic_to_brahmic_replace_pancham_varga_varna_with_anusvAra)
+            }
+            "all_to_sinhala:use_conjunct_enabling_halant" => {
+                Ok(self.all_to_sinhala_use_conjunct_enabling_halant)
+            }
+            "all_to_normal:remove_virAma_and_double_virAma" => {
+                Ok(self.all_to_normal_remove_virAma_and_double_virAma)
+            }
+            "all_to_normal:replace_avagraha_with_a" => {
+                Ok(self.all_to_normal_replace_avagraha_with_a)
+            }
+            "normal_to_all:use_typing_chars" => Ok(self.normal_to_all_use_typing_chars),
+            "all_to_normal:preserve_specific_chars" => {
+                Ok(self.all_to_normal_preserve_specific_chars)
+            }
+            _ => Err(UnknownCustomOptionKey),
+        }
+    }
+    /// Fixed-size array of canonical key/value pairs (`&opts.as_entries()` for a slice).
+    #[inline]
+    pub fn as_entries(&self) -> [(&'static str, bool); Self::ENTRY_COUNT] {
+        [
+            (
+                "all_to_normal:replace_pancham_varga_varna_with_n",
+                self.all_to_normal_replace_pancham_varga_varna_with_n,
+            ),
+            (
+                "brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra",
+                self.brahmic_to_brahmic_replace_pancham_varga_varna_with_anusvAra,
+            ),
+            (
+                "all_to_sinhala:use_conjunct_enabling_halant",
+                self.all_to_sinhala_use_conjunct_enabling_halant,
+            ),
+            (
+                "all_to_normal:remove_virAma_and_double_virAma",
+                self.all_to_normal_remove_virAma_and_double_virAma,
+            ),
+            (
+                "all_to_normal:replace_avagraha_with_a",
+                self.all_to_normal_replace_avagraha_with_a,
+            ),
+            ("normal_to_all:use_typing_chars", self.normal_to_all_use_typing_chars),
+            (
+                "all_to_normal:preserve_specific_chars",
+                self.all_to_normal_preserve_specific_chars,
+            ),
+        ]
+    }
+    /// Builds a hash map from canonical option keys (supports any `FromIterator<(String, bool)>` map, e.g. hashbrown or std).
+    #[inline]
+    pub fn to_options_map<M>(&self) -> M
+    where
+        M: FromIterator<(String, bool)>,
+    {
+        self.as_entries()
+            .iter()
+            .copied()
+            .map(|(key, enabled)| (key.to_string(), enabled))
+            .collect()
     }
 }
 impl CustomOptionsBuilder {

--- a/packages/rust/src/custom_options.rs
+++ b/packages/rust/src/custom_options.rs
@@ -42,13 +42,22 @@ impl CustomOptions {
         "normal_to_all:use_typing_chars",
         "all_to_normal:preserve_specific_chars",
     ];
+    /// Every option enabled (no runtime key lookup).
+    #[inline]
+    pub const fn all_enabled() -> Self {
+        Self {
+            all_to_normal_replace_pancham_varga_varna_with_n: true,
+            brahmic_to_brahmic_replace_pancham_varga_varna_with_anusvAra: true,
+            all_to_sinhala_use_conjunct_enabling_halant: true,
+            all_to_normal_remove_virAma_and_double_virAma: true,
+            all_to_normal_replace_avagraha_with_a: true,
+            normal_to_all_use_typing_chars: true,
+            all_to_normal_preserve_specific_chars: true,
+        }
+    }
     /// Sets an option by its canonical `category:option` key.
     #[inline]
-    pub fn try_set(
-        &mut self,
-        key: &str,
-        value: bool,
-    ) -> Result<(), UnknownCustomOptionKey> {
+    pub fn try_set(&mut self, key: &str, value: bool) -> Result<(), UnknownCustomOptionKey> {
         match key {
             "all_to_normal:replace_pancham_varga_varna_with_n" => {
                 self.all_to_normal_replace_pancham_varga_varna_with_n = value;
@@ -131,7 +140,10 @@ impl CustomOptions {
                 "all_to_normal:replace_avagraha_with_a",
                 self.all_to_normal_replace_avagraha_with_a,
             ),
-            ("normal_to_all:use_typing_chars", self.normal_to_all_use_typing_chars),
+            (
+                "normal_to_all:use_typing_chars",
+                self.normal_to_all_use_typing_chars,
+            ),
             (
                 "all_to_normal:preserve_specific_chars",
                 self.all_to_normal_preserve_specific_chars,
@@ -149,6 +161,43 @@ impl CustomOptions {
             .copied()
             .map(|(key, enabled)| (key.to_string(), enabled))
             .collect()
+    }
+    /// Builds [`CustomOptions`] from any map-like `(key, enabled)` source.
+    ///
+    /// Accepts [`hashbrown::HashMap`](hashbrown::HashMap), [`std::collections::HashMap`](std::collections::HashMap),
+    /// iterators of pairs, and other collections via [`IntoIterator`].
+    pub fn try_from_map<M, K, V>(map: M) -> Result<Self, UnknownCustomOptionKey>
+    where
+        M: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: core::borrow::Borrow<bool>,
+    {
+        let mut options = Self::default();
+        for (key, enabled) in map {
+            options.try_set(key.as_ref(), *enabled.borrow())?;
+        }
+        Ok(options)
+    }
+    /// Builds [`CustomOptions`] from a list of `(key, enabled)` pairs.
+    #[inline]
+    pub fn try_from_pairs<I, S>(pairs: I) -> Result<Self, UnknownCustomOptionKey>
+    where
+        I: IntoIterator<Item = (S, bool)>,
+        S: AsRef<str>,
+    {
+        Self::try_from_map(pairs)
+    }
+    /// Builds [`CustomOptions`] from an optional map-like source.
+    #[inline]
+    pub fn try_from_optional_map<M, K, V>(
+        map: Option<M>,
+    ) -> Result<Option<Self>, UnknownCustomOptionKey>
+    where
+        M: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: core::borrow::Borrow<bool>,
+    {
+        map.map(Self::try_from_map).transpose()
     }
 }
 impl CustomOptionsBuilder {

--- a/packages/rust/src/custom_options.rs
+++ b/packages/rust/src/custom_options.rs
@@ -57,11 +57,7 @@ impl CustomOptions {
     }
     /// Sets an option by its canonical `category:option` key.
     #[inline]
-    pub fn try_set(
-        &mut self,
-        key: &str,
-        value: bool,
-    ) -> Result<(), UnknownCustomOptionKey> {
+    pub fn try_set(&mut self, key: &str, value: bool) -> Result<(), UnknownCustomOptionKey> {
         match key {
             "all_to_normal:replace_pancham_varga_varna_with_n" => {
                 self.all_to_normal_replace_pancham_varga_varna_with_n = value;
@@ -144,7 +140,10 @@ impl CustomOptions {
                 "all_to_normal:replace_avagraha_with_a",
                 self.all_to_normal_replace_avagraha_with_a,
             ),
-            ("normal_to_all:use_typing_chars", self.normal_to_all_use_typing_chars),
+            (
+                "normal_to_all:use_typing_chars",
+                self.normal_to_all_use_typing_chars,
+            ),
             (
                 "all_to_normal:preserve_specific_chars",
                 self.all_to_normal_preserve_specific_chars,

--- a/packages/rust/src/custom_options.rs
+++ b/packages/rust/src/custom_options.rs
@@ -57,7 +57,11 @@ impl CustomOptions {
     }
     /// Sets an option by its canonical `category:option` key.
     #[inline]
-    pub fn try_set(&mut self, key: &str, value: bool) -> Result<(), UnknownCustomOptionKey> {
+    pub fn try_set(
+        &mut self,
+        key: &str,
+        value: bool,
+    ) -> Result<(), UnknownCustomOptionKey> {
         match key {
             "all_to_normal:replace_pancham_varga_varna_with_n" => {
                 self.all_to_normal_replace_pancham_varga_varna_with_n = value;
@@ -140,10 +144,7 @@ impl CustomOptions {
                 "all_to_normal:replace_avagraha_with_a",
                 self.all_to_normal_replace_avagraha_with_a,
             ),
-            (
-                "normal_to_all:use_typing_chars",
-                self.normal_to_all_use_typing_chars,
-            ),
+            ("normal_to_all:use_typing_chars", self.normal_to_all_use_typing_chars),
             (
                 "all_to_normal:preserve_specific_chars",
                 self.all_to_normal_preserve_specific_chars,

--- a/packages/rust/src/custom_options.rs
+++ b/packages/rust/src/custom_options.rs
@@ -1,0 +1,28 @@
+#[rustfmt::skip]
+use derive_builder::Builder;
+/// Enabled/disabled flags for each transliteration custom option key
+///
+/// Use [`CustomOptionsBuilder::default`] and `<category>_<option>(bool)` setters, or
+/// [`CustomOptions::default`] for all options disabled.
+///
+/// for list of supported options you can visit [Custom Options](https://lipilekhika.in/reference/custom_trans_options/)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Builder)]
+#[builder(no_std, default, pattern = "owned", build_fn(name = "try_build"))]
+#[allow(non_snake_case)]
+pub struct CustomOptions {
+    pub all_to_normal_replace_pancham_varga_varna_with_n: bool,
+    pub brahmic_to_brahmic_replace_pancham_varga_varna_with_anusvAra: bool,
+    pub all_to_sinhala_use_conjunct_enabling_halant: bool,
+    pub all_to_normal_remove_virAma_and_double_virAma: bool,
+    pub all_to_normal_replace_avagraha_with_a: bool,
+    pub normal_to_all_use_typing_chars: bool,
+    pub all_to_normal_preserve_specific_chars: bool,
+}
+impl CustomOptionsBuilder {
+    /// Infallible build: every field has a `bool` default via [`Default`].
+    #[inline]
+    pub fn build(self) -> CustomOptions {
+        self.try_build()
+            .expect("CustomOptionsBuilder: infallible with `#[builder(default)]`")
+    }
+}

--- a/packages/rust/src/custom_options.rs
+++ b/packages/rust/src/custom_options.rs
@@ -1,22 +1,73 @@
 #[rustfmt::skip]
 use derive_builder::Builder;
-/// Enabled/disabled flags for each transliteration custom option key
+/// Returned when [`CustomOptions::try_set`] is called with an unknown option key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownCustomOptionKey;
+/// Custom transliteration options struct
 ///
 /// Use [`CustomOptionsBuilder::default`] and `<category>_<option>(bool)` setters, or
 /// [`CustomOptions::default`] for all options disabled.
 ///
-/// for list of supported options you can visit [Custom Options](https://lipilekhika.in/reference/custom_trans_options/)
+/// For a list of supported options visit [Custom Options](https://lipilekhika.in/reference/custom_trans_options/).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Builder)]
 #[builder(no_std, default, pattern = "owned", build_fn(name = "try_build"))]
 #[allow(non_snake_case)]
 pub struct CustomOptions {
+    ///`all_to_normal:replace_pancham_varga_varna_with_n`
     pub all_to_normal_replace_pancham_varga_varna_with_n: bool,
+    ///`brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra`
     pub brahmic_to_brahmic_replace_pancham_varga_varna_with_anusvAra: bool,
+    ///`all_to_sinhala:use_conjunct_enabling_halant`
     pub all_to_sinhala_use_conjunct_enabling_halant: bool,
+    ///`all_to_normal:remove_virAma_and_double_virAma`
     pub all_to_normal_remove_virAma_and_double_virAma: bool,
+    ///`all_to_normal:replace_avagraha_with_a`
     pub all_to_normal_replace_avagraha_with_a: bool,
+    ///`normal_to_all:use_typing_chars`
     pub normal_to_all_use_typing_chars: bool,
+    ///`all_to_normal:preserve_specific_chars`
     pub all_to_normal_preserve_specific_chars: bool,
+}
+impl CustomOptions {
+    /// Sets an option by its canonical `category:option` key.
+    #[inline]
+    pub fn try_set(
+        &mut self,
+        key: &str,
+        value: bool,
+    ) -> Result<(), UnknownCustomOptionKey> {
+        match key {
+            "all_to_normal:replace_pancham_varga_varna_with_n" => {
+                self.all_to_normal_replace_pancham_varga_varna_with_n = value;
+                Ok(())
+            }
+            "brahmic_to_brahmic:replace_pancham_varga_varna_with_anusvAra" => {
+                self.brahmic_to_brahmic_replace_pancham_varga_varna_with_anusvAra = value;
+                Ok(())
+            }
+            "all_to_sinhala:use_conjunct_enabling_halant" => {
+                self.all_to_sinhala_use_conjunct_enabling_halant = value;
+                Ok(())
+            }
+            "all_to_normal:remove_virAma_and_double_virAma" => {
+                self.all_to_normal_remove_virAma_and_double_virAma = value;
+                Ok(())
+            }
+            "all_to_normal:replace_avagraha_with_a" => {
+                self.all_to_normal_replace_avagraha_with_a = value;
+                Ok(())
+            }
+            "normal_to_all:use_typing_chars" => {
+                self.normal_to_all_use_typing_chars = value;
+                Ok(())
+            }
+            "all_to_normal:preserve_specific_chars" => {
+                self.all_to_normal_preserve_specific_chars = value;
+                Ok(())
+            }
+            _ => Err(UnknownCustomOptionKey),
+        }
+    }
 }
 impl CustomOptionsBuilder {
     /// Infallible build: every field has a `bool` default via [`Default`].

--- a/packages/rust/src/custom_options.rs
+++ b/packages/rust/src/custom_options.rs
@@ -57,7 +57,12 @@ impl CustomOptions {
     }
     /// Sets an option by its canonical `category:option` key.
     #[inline]
-    pub fn try_set(&mut self, key: &str, value: bool) -> Result<(), UnknownCustomOptionKey> {
+    #[rustfmt::skip]
+    pub fn try_set(
+        &mut self,
+        key: &str,
+        value: bool,
+    ) -> Result<(), UnknownCustomOptionKey> {
         match key {
             "all_to_normal:replace_pancham_varga_varna_with_n" => {
                 self.all_to_normal_replace_pancham_varga_varna_with_n = value;
@@ -118,6 +123,7 @@ impl CustomOptions {
     }
     /// Fixed-size array of canonical key/value pairs (`&opts.as_entries()` for a slice).
     #[inline]
+    #[rustfmt::skip]
     pub fn as_entries(&self) -> [(&'static str, bool); Self::ENTRY_COUNT] {
         [
             (
@@ -140,10 +146,7 @@ impl CustomOptions {
                 "all_to_normal:replace_avagraha_with_a",
                 self.all_to_normal_replace_avagraha_with_a,
             ),
-            (
-                "normal_to_all:use_typing_chars",
-                self.normal_to_all_use_typing_chars,
-            ),
+            ("normal_to_all:use_typing_chars", self.normal_to_all_use_typing_chars),
             (
                 "all_to_normal:preserve_specific_chars",
                 self.all_to_normal_preserve_specific_chars,

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -24,7 +24,7 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 pub use hashbrown::HashMap;
 // ^ only exposed for internal use in bindings
-pub use custom_options::{CustomOptions, CustomOptionsBuilder};
+pub use custom_options::{CustomOptions, CustomOptionsBuilder, UnknownCustomOptionKey};
 pub use scripts::{Script, ScriptListEnum};
 mod script_data;
 mod transliterate;

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -43,7 +43,7 @@ pub fn transliterate<'a>(
     text: &'a (impl AsRef<str> + ?Sized),
     from: Script,
     to: Script,
-    trans_options: Option<&HashMap<String, bool>>,
+    trans_options: Option<&CustomOptions>,
 ) -> Cow<'a, str> {
     let text = text.as_ref();
     let from: ScriptListEnum = from.into();

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -27,7 +27,9 @@ mod script_data;
 mod transliterate;
 mod utils;
 
+#[rustfmt::skip]
 pub mod custom_options;
+#[rustfmt::skip]
 pub mod scripts;
 pub mod typing;
 

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -24,11 +24,13 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 pub use hashbrown::HashMap;
 // ^ only exposed for internal use in bindings
+pub use custom_options::{CustomOptions, CustomOptionsBuilder};
 pub use scripts::{Script, ScriptListEnum};
 mod script_data;
 mod transliterate;
 mod utils;
 
+pub mod custom_options;
 pub mod scripts;
 pub mod typing;
 

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -21,9 +21,6 @@ pub use crate::typing::{
     get_script_typing_data_map,
 };
 use alloc::borrow::Cow;
-use alloc::string::String;
-pub use hashbrown::HashMap;
-// ^ only exposed for internal use in bindings
 pub use custom_options::{CustomOptions, CustomOptionsBuilder, UnknownCustomOptionKey};
 pub use scripts::{Script, ScriptListEnum};
 mod script_data;
@@ -78,9 +75,14 @@ mod tests {
     use super::*;
 
     use crate::scripts::Script;
-    use alloc::{format, string::ToString, vec::Vec};
+    use alloc::{
+        format,
+        string::{String, ToString},
+        vec::Vec,
+    };
     use owo_colors::OwoColorize;
     use serde::Deserialize;
+    use std::collections::HashMap;
     use std::fs;
     use std::io::Write;
     use std::path::{Path, PathBuf};
@@ -154,6 +156,22 @@ mod tests {
         reversible: Option<bool>,
         #[serde(default)]
         todo: Option<bool>,
+    }
+
+    fn options_from_map(
+        map: Option<&HashMap<String, bool>>,
+        file: &Path,
+        index: &str,
+    ) -> Option<CustomOptions> {
+        map.map(|options| {
+            CustomOptions::try_from_map(options).unwrap_or_else(|_| {
+                panic!(
+                    "invalid custom option key in `{}` index {}",
+                    file.display(),
+                    index
+                )
+            })
+        })
     }
 
     fn list_yaml_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
@@ -307,7 +325,8 @@ mod tests {
                 }
             };
 
-            let result = transliterate(&case.input, from, to, case.options.as_ref());
+            let options = options_from_map(case.options.as_ref(), file_path, &case.index);
+            let result = transliterate(&case.input, from, to, options.as_ref());
 
             if file_name.starts_with("auto")
                 && case.to == "Tamil-Extended"
@@ -340,7 +359,7 @@ mod tests {
 
             if case.reversible.unwrap_or(false) {
                 stats.reverse_asserts += 1;
-                let reversed = transliterate(&result, to, from, case.options.as_ref());
+                let reversed = transliterate(&result, to, from, options.as_ref());
 
                 if reversed == case.input {
                     stats.reverse_passed += 1;

--- a/packages/rust/src/script_data/mod.rs
+++ b/packages/rust/src/script_data/mod.rs
@@ -7,7 +7,6 @@ mod script_list;
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use hashbrown::HashMap;
 
 pub use custom_options::*;
 pub use schema::*;
@@ -20,15 +19,8 @@ use crate::scripts::Script;
 pub fn get_all_options(from_script: Script, to_script: Script) -> Vec<String> {
     let from_script_data = ScriptData::get_script_data(&from_script.into());
     let to_script_data = ScriptData::get_script_data(&to_script.into());
-
-    // Create a HashMap with all custom options set to true.
-    // `custom_options_map` is insertion-ordered (same as `custom_options.json`),
-    // but `HashMap` is not. We only use this for lookup below.
     let custom_options_map = get_custom_options_map();
-    let all_options_enabled: HashMap<String, bool> = custom_options_map
-        .keys()
-        .map(|key| (key.clone(), true))
-        .collect();
+    let all_options_enabled = crate::CustomOptions::all_enabled();
 
     let active_options = crate::transliterate::transliterate::get_active_custom_options(
         from_script_data,
@@ -39,7 +31,7 @@ pub fn get_all_options(from_script: Script, to_script: Script) -> Vec<String> {
     // Preserve `custom_options.json` order by filtering in that key order.
     let mut ordered: Vec<String> = Vec::new();
     for key in custom_options_map.keys() {
-        if active_options.contains_key(key) {
+        if active_options.get(key.as_str()).unwrap_or(false) {
             ordered.push(key.clone());
         }
     }

--- a/packages/rust/src/transliterate/transliterate.rs
+++ b/packages/rust/src/transliterate/transliterate.rs
@@ -1,3 +1,4 @@
+use crate::custom_options::CustomOptions;
 use crate::script_data::{CheckInEnum, CustomOptionScriptTypeEnum, List, Rule, ScriptData};
 use crate::scripts::ScriptListEnum;
 use crate::transliterate::helpers::{
@@ -9,7 +10,6 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::slice;
-use hashbrown::HashMap;
 
 /// Compare a char with a &str without heap allocation.
 #[inline]
@@ -24,7 +24,7 @@ struct TransliterateCtx<'a, R> {
     to_script: &'a ScriptListEnum,
     from_script_data: &'a ScriptData,
     to_script_data: &'a ScriptData,
-    trans_options: &'a HashMap<String, bool>,
+    trans_options: &'a CustomOptions,
     custom_rules: &'a [R],
     cursor: &'a mut InputTextCursor<'a>,
     result: &'a mut ResultStringBuilder,
@@ -165,10 +165,9 @@ where
                     );
 
                     if self.to_script == &ScriptListEnum::Sinhala
-                        && *self
+                        && self
                             .trans_options
-                            .get("all_to_sinhala:use_conjunct_enabling_halant")
-                            .unwrap_or(&false)
+                            .all_to_sinhala_use_conjunct_enabling_halant
                         && let Some(last_piece) = self.result.last_piece()
                     {
                         self.result.rewrite_at(-1, &{
@@ -205,10 +204,9 @@ where
                     .emit_pieces_with_reorder(&[brahmic_halant], to_halant, should_reorder);
 
                 if *self.to_script == ScriptListEnum::Sinhala
-                    && *self
+                    && self
                         .trans_options
-                        .get("all_to_sinhala:use_conjunct_enabling_halant")
-                        .unwrap_or(&false)
+                        .all_to_sinhala_use_conjunct_enabling_halant
                     && let Some(last_piece) = self.result.last_piece()
                 {
                     self.result.rewrite_at(-1, &{
@@ -398,21 +396,21 @@ fn custom_option_script_type_matches(
 pub fn get_active_custom_options(
     from_script_data: &ScriptData,
     to_script_data: &ScriptData,
-    input_options: Option<&HashMap<String, bool>>,
-) -> HashMap<String, bool> {
+    input_options: Option<&CustomOptions>,
+) -> CustomOptions {
     let Some(input_options) = input_options else {
-        return HashMap::new();
+        return CustomOptions::default();
     };
 
     let from_script_name = &from_script_data.script_name;
     let to_script_name = &to_script_data.script_name;
     let custom_options_map = crate::script_data::get_custom_options_map();
-    let mut active: HashMap<String, bool> = HashMap::with_capacity(input_options.len());
+    let mut active = CustomOptions::default();
 
     let from_type = custom_option_script_type_of(from_script_data);
     let to_type = custom_option_script_type_of(to_script_data);
 
-    for (key, enabled) in input_options.iter() {
+    for (key, enabled) in input_options.as_entries() {
         let Some(option_info) = custom_options_map.get(key) else {
             continue;
         };
@@ -437,7 +435,9 @@ pub fn get_active_custom_options(
                 .is_some_and(|names| names.iter().any(|n| n == to_script_name));
 
         if from_matches && to_matches {
-            active.insert(key.clone(), *enabled);
+            active
+                .try_set(key, enabled)
+                .expect("CustomOptions keys must remain in sync with custom_options.json");
         }
     }
 
@@ -446,14 +446,14 @@ pub fn get_active_custom_options(
 
 #[derive(Debug, Clone)]
 pub struct ResolvedTransliterationRules {
-    pub trans_options: HashMap<String, bool>,
+    pub trans_options: CustomOptions,
     pub custom_rules: Vec<&'static Rule>,
 }
 /// Resolves active options once and flattens enabled rules into a single list.
 pub fn resolve_transliteration_rules(
     from_script_data: &ScriptData,
     to_script_data: &ScriptData,
-    transliteration_input_options: Option<&HashMap<String, bool>>,
+    transliteration_input_options: Option<&CustomOptions>,
 ) -> ResolvedTransliterationRules {
     let trans_options = get_active_custom_options(
         from_script_data,
@@ -464,8 +464,8 @@ pub fn resolve_transliteration_rules(
     let custom_options_map = crate::script_data::get_custom_options_map();
     let mut custom_rules: Vec<&'static Rule> = Vec::new();
 
-    for (key, enabled) in trans_options.iter() {
-        if !*enabled {
+    for (key, enabled) in trans_options.as_entries() {
+        if !enabled {
             continue;
         }
         if let Some(opt) = custom_options_map.get(key) {
@@ -649,7 +649,7 @@ pub fn transliterate_text_core(
     to_script: &ScriptListEnum,
     from_script_data: &ScriptData,
     to_script_data: &ScriptData,
-    trans_options_in: &HashMap<String, bool>,
+    trans_options_in: &CustomOptions,
     custom_rules: &[impl Borrow<Rule>],
     options: Option<TransliterationFnOptions>,
 ) -> TransliterationOutput {
@@ -661,8 +661,6 @@ pub fn transliterate_text_core(
         // as it is only called internally in `typing.rs` with from always being "Normal"
     }
 
-    // Only clone trans_options when we actually need to insert a key (typing mode).
-    // In the common (non-typing) path this avoids a full HashMap allocation per call.
     let trans_options = trans_options_in;
     // ^ now we use this flag itself for adding custom
     // `normal_to_all:use_typing_chars` rule used to modidy the behaviour
@@ -702,10 +700,7 @@ pub fn transliterate_text_core(
         _ => (None, None),
     };
 
-    let trans_opt_normal_to_all_use_typing_chars: bool = trans_options
-        .get("normal_to_all:use_typing_chars")
-        .copied()
-        .unwrap_or(false);
+    let trans_opt_normal_to_all_use_typing_chars = trans_options.normal_to_all_use_typing_chars;
     // choose matching map
     let use_typing_map = (trans_opt_normal_to_all_use_typing_chars || opts.typing_mode)
         && *from_script == ScriptListEnum::Normal;
@@ -725,10 +720,8 @@ pub fn transliterate_text_core(
 
     let is_from_tamil_ext_ = is_script_tamil_ext(from_script);
     let is_to_tamil_ext_ = is_script_tamil_ext(to_script);
-    let opt_preserve_specific_chars_ = *trans_options
-        .get("all_to_normal:preserve_specific_chars")
-        .unwrap_or(&false)
-        && *to_script == ScriptListEnum::Normal;
+    let opt_preserve_specific_chars_ =
+        trans_options.all_to_normal_preserve_specific_chars && *to_script == ScriptListEnum::Normal;
 
     let mut ctx = TransliterateCtx {
         from_script,
@@ -1455,7 +1448,7 @@ pub fn transliterate_text(
     text: impl AsRef<str>,
     from_script: ScriptListEnum,
     to_script: ScriptListEnum,
-    transliteration_input_options: Option<&HashMap<String, bool>>,
+    transliteration_input_options: Option<&CustomOptions>,
     options: Option<TransliterationFnOptions>,
 ) -> TransliterationOutput {
     let text = text.as_ref();

--- a/packages/rust/src/typing.rs
+++ b/packages/rust/src/typing.rs
@@ -2,6 +2,7 @@
 //! and script typing-data helpers. Enable the crate `std` feature for idle auto-clear via
 //! `std::time`; otherwise clear context explicitly.
 
+use crate::custom_options::CustomOptions;
 use crate::scripts::{Script, ScriptListEnum};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
@@ -87,7 +88,7 @@ pub struct TypingContext {
 
     from_script_data: &'static ScriptData,
     to_script_data: &'static ScriptData,
-    trans_options: HashMap<String, bool>,
+    trans_options: CustomOptions,
     custom_rules: Vec<&'static crate::script_data::Rule>,
 }
 
@@ -802,8 +803,10 @@ mod tests {
                 if case.preserve_check {
                     preserve_checks += 1;
                     // Transliterate back to Normal with `all_to_normal:preserve_specific_chars`
-                    let mut trans_options = HashMap::new();
-                    trans_options.insert("all_to_normal:preserve_specific_chars".to_string(), true);
+                    let mut trans_options = CustomOptions::default();
+                    trans_options
+                        .try_set("all_to_normal:preserve_specific_chars", true)
+                        .unwrap();
 
                     let preserved =
                         crate::transliterate(&result, script, Script::Normal, Some(&trans_options));


### PR DESCRIPTION
- **init**
- **format**
- **try_set for raw keys**
- **prepeare**
- **done**
- **corrected docs**
- **format**
- **format issues fixx**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced typed `CustomOptions` API for transliteration custom options with improved type safety and validation across all language bindings.

* **Bug Fixes**
  * Enhanced error handling to validate option keys and provide clearer error messages for invalid options.

* **Documentation**
  * Updated API documentation for Rust, JavaScript, Python, and WASM to reflect new `CustomOptions` approach with builder pattern examples.

* **Performance**
  * Reduced WASM bundle size from 117 KB to 114 KB.

* **Tests**
  * Added test coverage for custom options across JavaScript bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->