### PR TITLE
feat: Add MacOS support for Dekstop client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-graphics"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-graphics-types 0.2.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
 name = "core-graphics-types"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,11 +4039,14 @@ dependencies = [
 name = "lipilekhika-ui"
 version = "1.0.11"
 dependencies = [
+ "core-foundation 0.10.1",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dark-light",
  "dirs",
  "dotenvy",
  "embed-resource 2.5.2",
+ "foreign-types",
  "iced",
  "iced_aw",
  "iced_futures",

--- a/desktop-client/Cargo.toml
+++ b/desktop-client/Cargo.toml
@@ -34,6 +34,11 @@ windows = { version = "0.62.2", features = [
     "Win32_Globalization",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-graphics = "0.25"
+core-foundation = "0.10"
+foreign-types = "0.5"
+
 [build-dependencies]
 embed-resource = "2"
 dotenvy = "0.15.7"

--- a/desktop-client/src/mac/constants.rs
+++ b/desktop-client/src/mac/constants.rs
@@ -1,0 +1,35 @@
+// macOS key codes (CGKeyCode) — re-exported from core_graphics::event::KeyCode
+// for the key categories needed by the hook logic.
+
+use core_graphics::event::KeyCode;
+
+// Letters (toggle shortcut)
+pub const VK_X: u16 = KeyCode::ANSI_X;
+pub const VK_C: u16 = KeyCode::ANSI_C;
+
+// Navigation & editing keys that clear context
+pub const VK_LEFT: u16 = KeyCode::LEFT_ARROW;
+pub const VK_UP: u16 = KeyCode::UP_ARROW;
+pub const VK_RIGHT: u16 = KeyCode::RIGHT_ARROW;
+pub const VK_DOWN: u16 = KeyCode::DOWN_ARROW;
+pub const VK_HOME: u16 = KeyCode::HOME;
+pub const VK_END: u16 = KeyCode::END;
+pub const VK_PAGE_UP: u16 = KeyCode::PAGE_UP;
+pub const VK_PAGE_DOWN: u16 = KeyCode::PAGE_DOWN;
+pub const VK_FORWARD_DELETE: u16 = KeyCode::FORWARD_DELETE;
+pub const VK_RETURN: u16 = KeyCode::RETURN;
+pub const VK_TAB: u16 = KeyCode::TAB;
+pub const VK_ESCAPE: u16 = KeyCode::ESCAPE;
+pub const VK_DELETE: u16 = KeyCode::DELETE; // Backspace on macOS
+
+// Modifier keys (pass through without processing)
+pub const VK_SHIFT: u16 = KeyCode::SHIFT;
+pub const VK_RIGHT_SHIFT: u16 = KeyCode::RIGHT_SHIFT;
+pub const VK_CONTROL: u16 = KeyCode::CONTROL;
+pub const VK_RIGHT_CONTROL: u16 = KeyCode::RIGHT_CONTROL;
+pub const VK_OPTION: u16 = KeyCode::OPTION;
+pub const VK_RIGHT_OPTION: u16 = KeyCode::RIGHT_OPTION;
+pub const VK_COMMAND: u16 = KeyCode::COMMAND;
+pub const VK_RIGHT_COMMAND: u16 = KeyCode::RIGHT_COMMAND;
+pub const VK_CAPS_LOCK: u16 = KeyCode::CAPS_LOCK;
+pub const VK_FUNCTION: u16 = KeyCode::FUNCTION;

--- a/desktop-client/src/mac/hooks.rs
+++ b/desktop-client/src/mac/hooks.rs
@@ -68,55 +68,65 @@ fn tag_injected(event: &CGEvent) {
 }
 
 /// Post a key down+up pair for `keycode`, optionally setting the Unicode string.
-fn post_key(source: CGEventSource, keycode: u16, text: Option<&str>) {
-  if let Ok(down) = CGEvent::new_keyboard_event(source.clone(), keycode, true) {
-    if let Some(s) = text {
-      down.set_string(s);
-    }
-    tag_injected(&down);
-    down.post(CGEventTapLocation::HID);
+fn post_key(source: CGEventSource, keycode: u16, text: Option<&str>) -> bool {
+  let Ok(down) = CGEvent::new_keyboard_event(source.clone(), keycode, true) else {
+    return false;
+  };
+  if let Some(s) = text {
+    down.set_string(s);
   }
-  if let Ok(up) = CGEvent::new_keyboard_event(source, keycode, false) {
-    tag_injected(&up);
-    up.post(CGEventTapLocation::HID);
-  }
+  let Ok(up) = CGEvent::new_keyboard_event(source, keycode, false) else {
+    return false;
+  };
+
+  tag_injected(&down);
+  tag_injected(&up);
+
+  down.post(CGEventTapLocation::HID);
+  up.post(CGEventTapLocation::HID);
+
+  true
 }
 
 /// Send a Unicode string via a single SPACE key event with the string attached.
-fn send_unicode_text(s: &str) {
+fn send_unicode_text(s: &str) -> bool {
   let Some(source) = CGEventSource::new(CGEventSourceStateID::Private).ok() else {
-    return;
+    return false;
   };
-  post_key(source, KeyCode::SPACE, Some(s));
+  post_key(source, KeyCode::SPACE, Some(s))
 }
 
 /// Send backspace key n times.
-fn send_backspaces(n: usize) {
+fn send_backspaces(n: usize) -> bool {
   let Some(source) = CGEventSource::new(CGEventSourceStateID::Private).ok() else {
-    return;
+    return false;
   };
 
   for _ in 0..n {
-    post_key(source.clone(), KeyCode::DELETE, None);
+    if !post_key(source.clone(), KeyCode::DELETE, None) {
+      return false;
+    }
   }
+
+  true
 }
 
 /// Read the Unicode string from a keyboard event via CGEventKeyboardGetUnicodeString.
 fn get_event_string(event: &CGEvent) -> Option<String> {
   unsafe {
-    let mut buf = [0u16; 8];
     let mut len: core::ffi::c_ulong = 0;
-    CGEventKeyboardGetUnicodeString(
-      event.as_ptr(),
-      buf.len() as core::ffi::c_ulong,
-      &mut len,
-      buf.as_mut_ptr(),
-    );
-    if len > 0 {
-      Some(String::from_utf16_lossy(&buf[..len as usize]))
-    } else {
-      None
+    CGEventKeyboardGetUnicodeString(event.as_ptr(), 0, &mut len, std::ptr::null_mut());
+
+    if len == 0 {
+      return None;
     }
+
+    let mut buf = vec![0u16; len as usize];
+    CGEventKeyboardGetUnicodeString(event.as_ptr(), len, &mut len, buf.as_mut_ptr());
+    let len = len.min(buf.len() as core::ffi::c_ulong);
+    buf.truncate(len as usize);
+
+    Some(String::from_utf16_lossy(&buf))
   }
 }
 
@@ -189,6 +199,8 @@ pub fn build_event_tap_callback(
     if is_keydown
       && (keycode == VK_X || keycode == VK_C)
       && flags.contains(CGEventFlags::CGEventFlagAlternate)
+      && !flags.contains(CGEventFlags::CGEventFlagCommand)
+      && !flags.contains(CGEventFlags::CGEventFlagControl)
     {
       // a xor 1 = !a
       let now_enabled = !state
@@ -290,13 +302,13 @@ pub fn build_event_tap_callback(
       (total_delete, combined_add)
     };
 
-    if total_delete > 0 {
-      send_backspaces(total_delete);
-    }
-    if !combined_add.is_empty() {
-      send_unicode_text(&combined_add);
-    }
+    let deleted = total_delete == 0 || send_backspaces(total_delete);
+    let added = combined_add.is_empty() || send_unicode_text(&combined_add);
 
-    CallbackResult::Drop
+    if deleted && added {
+      CallbackResult::Drop
+    } else {
+      CallbackResult::Keep
+    }
   }
 }

--- a/desktop-client/src/mac/hooks.rs
+++ b/desktop-client/src/mac/hooks.rs
@@ -2,7 +2,10 @@ use crate::{ThreadMessage, ThreadMessageOrigin, ThreadMessageType};
 
 use super::MacAppState;
 use super::constants::*;
+use core_foundation::base::TCFType;
+use core_foundation::mach_port::{CFMachPort, CFMachPortRef};
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::Ordering;
 
 use core_graphics::event::{
@@ -89,11 +92,12 @@ fn send_unicode_text(s: &str) {
 
 /// Send backspace key n times.
 fn send_backspaces(n: usize) {
+  let Some(source) = CGEventSource::new(CGEventSourceStateID::Private).ok() else {
+    return;
+  };
+
   for _ in 0..n {
-    let Some(source) = CGEventSource::new(CGEventSourceStateID::Private).ok() else {
-      return;
-    };
-    post_key(source, KeyCode::DELETE, None);
+    post_key(source.clone(), KeyCode::DELETE, None);
   }
 }
 
@@ -124,6 +128,8 @@ unsafe extern "C" {
     actualStringLength: *mut core::ffi::c_ulong,
     unicodeString: *mut u16,
   );
+
+  fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
 }
 
 // ---- Event tap callback ----
@@ -132,14 +138,21 @@ unsafe extern "C" {
 /// Logic mirrors `win/hooks.rs` — see comments there for rationale.
 pub fn build_event_tap_callback(
   state: Arc<MacAppState>,
-) -> impl Fn(CGEventTapProxy, CGEventType, &CGEvent) -> CallbackResult + Send + 'static {
+  tap_port: Arc<Mutex<Option<CFMachPort>>>,
+) -> impl Fn(CGEventTapProxy, CGEventType, &CGEvent) -> CallbackResult + 'static {
   move |_proxy, event_type, event| {
     // Handle tap-disabled events
     if matches!(
       event_type,
       CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput
     ) {
-      eprintln!("[lipilekhika] Event tap disabled ({event_type:?}), will be re-enabled");
+      if let Ok(guard) = tap_port.lock() {
+        if let Some(port) = guard.as_ref() {
+          unsafe {
+            CGEventTapEnable(port.as_concrete_TypeRef(), true);
+          }
+        }
+      }
       return CallbackResult::Keep;
     }
 

--- a/desktop-client/src/mac/hooks.rs
+++ b/desktop-client/src/mac/hooks.rs
@@ -1,0 +1,289 @@
+use crate::{ThreadMessage, ThreadMessageOrigin, ThreadMessageType};
+
+use super::MacAppState;
+use super::constants::*;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use core_graphics::event::{
+  CGEvent, CGEventFlags, CGEventTapLocation, CGEventTapProxy, CGEventType, CallbackResult,
+  EventField, KeyCode,
+};
+use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+use foreign_types::ForeignType;
+
+/// Sentinel set on injected events' `EVENT_SOURCE_USER_DATA` field
+/// so the tap callback can skip them (analogous to LLKHF_INJECTED_FLAG on Windows).
+const INJECTED_EVENT_SENTINEL: i64 = 0x4C49_5049; // "LIPI"
+
+fn clear_context(state: &MacAppState) {
+  if let Ok(mut guard) = state.app_state.typing_context.lock() {
+    guard.clear_context();
+  }
+}
+
+fn is_modifier_key(keycode: u16) -> bool {
+  matches!(
+    keycode,
+    VK_SHIFT
+      | VK_RIGHT_SHIFT
+      | VK_CONTROL
+      | VK_RIGHT_CONTROL
+      | VK_OPTION
+      | VK_RIGHT_OPTION
+      | VK_COMMAND
+      | VK_RIGHT_COMMAND
+      | VK_CAPS_LOCK
+      | VK_FUNCTION
+  )
+}
+
+fn is_context_clear_key(keycode: u16) -> bool {
+  matches!(
+    keycode,
+    VK_DELETE
+      | VK_FORWARD_DELETE
+      | VK_RETURN
+      | VK_TAB
+      | VK_ESCAPE
+      | VK_LEFT
+      | VK_RIGHT
+      | VK_UP
+      | VK_DOWN
+      | VK_HOME
+      | VK_END
+      | VK_PAGE_UP
+      | VK_PAGE_DOWN
+  )
+}
+
+// ---- Input injection helpers ----
+
+/// Tag an event as injected so the tap callback skips it.
+fn tag_injected(event: &CGEvent) {
+  event.set_integer_value_field(EventField::EVENT_SOURCE_USER_DATA, INJECTED_EVENT_SENTINEL);
+}
+
+/// Post a key down+up pair for `keycode`, optionally setting the Unicode string.
+fn post_key(source: CGEventSource, keycode: u16, text: Option<&str>) {
+  if let Ok(down) = CGEvent::new_keyboard_event(source.clone(), keycode, true) {
+    if let Some(s) = text {
+      down.set_string(s);
+    }
+    tag_injected(&down);
+    down.post(CGEventTapLocation::HID);
+  }
+  if let Ok(up) = CGEvent::new_keyboard_event(source, keycode, false) {
+    tag_injected(&up);
+    up.post(CGEventTapLocation::HID);
+  }
+}
+
+/// Send a Unicode string via a single SPACE key event with the string attached.
+fn send_unicode_text(s: &str) {
+  let Some(source) = CGEventSource::new(CGEventSourceStateID::Private).ok() else {
+    return;
+  };
+  post_key(source, KeyCode::SPACE, Some(s));
+}
+
+/// Send backspace key n times.
+fn send_backspaces(n: usize) {
+  for _ in 0..n {
+    let Some(source) = CGEventSource::new(CGEventSourceStateID::Private).ok() else {
+      return;
+    };
+    post_key(source, KeyCode::DELETE, None);
+  }
+}
+
+/// Read the Unicode string from a keyboard event via CGEventKeyboardGetUnicodeString.
+fn get_event_string(event: &CGEvent) -> Option<String> {
+  unsafe {
+    let mut buf = [0u16; 8];
+    let mut len: core::ffi::c_ulong = 0;
+    CGEventKeyboardGetUnicodeString(
+      event.as_ptr(),
+      buf.len() as core::ffi::c_ulong,
+      &mut len,
+      buf.as_mut_ptr(),
+    );
+    if len > 0 {
+      Some(String::from_utf16_lossy(&buf[..len as usize]))
+    } else {
+      None
+    }
+  }
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+  fn CGEventKeyboardGetUnicodeString(
+    event: core_graphics::sys::CGEventRef,
+    maxStringLength: core::ffi::c_ulong,
+    actualStringLength: *mut core::ffi::c_ulong,
+    unicodeString: *mut u16,
+  );
+}
+
+// ---- Event tap callback ----
+
+/// Build the CGEventTap callback closure.
+/// Logic mirrors `win/hooks.rs` — see comments there for rationale.
+pub fn build_event_tap_callback(
+  state: Arc<MacAppState>,
+) -> impl Fn(CGEventTapProxy, CGEventType, &CGEvent) -> CallbackResult + Send + 'static {
+  move |_proxy, event_type, event| {
+    // Handle tap-disabled events
+    if matches!(
+      event_type,
+      CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput
+    ) {
+      eprintln!("[lipilekhika] Event tap disabled ({event_type:?}), will be re-enabled");
+      return CallbackResult::Keep;
+    }
+
+    // Skip our own injected events
+    if event.get_integer_value_field(EventField::EVENT_SOURCE_USER_DATA) == INJECTED_EVENT_SENTINEL
+    {
+      return CallbackResult::Keep;
+    }
+
+    // Mouse clicks → clear context
+    if matches!(
+      event_type,
+      CGEventType::LeftMouseDown | CGEventType::RightMouseDown | CGEventType::OtherMouseDown
+    ) {
+      if state.app_state.typing_enabled.load(Ordering::SeqCst) {
+        clear_context(&state);
+      }
+      return CallbackResult::Keep;
+    }
+
+    // Only keyboard events from here
+    if !matches!(
+      event_type,
+      CGEventType::KeyDown | CGEventType::KeyUp | CGEventType::FlagsChanged
+    ) {
+      return CallbackResult::Keep;
+    }
+
+    let keycode = event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE) as u16;
+    let flags = event.get_flags();
+    let is_keydown = matches!(event_type, CGEventType::KeyDown);
+
+    // ---- Option+X / Option+C toggle (works regardless of typing mode) ----
+    if is_keydown
+      && (keycode == VK_X || keycode == VK_C)
+      && flags.contains(CGEventFlags::CGEventFlagAlternate)
+    {
+      // a xor 1 = !a
+      let now_enabled = !state
+        .app_state
+        .typing_enabled
+        .fetch_xor(true, Ordering::SeqCst);
+
+      if !now_enabled {
+        clear_context(&state);
+      }
+
+      let _ = state.tx_ui.send(ThreadMessage {
+        origin: ThreadMessageOrigin::KeyboardHook,
+        msg: ThreadMessageType::TriggerTypingNotification,
+      });
+      let _ = state.tx_ui.send(ThreadMessage {
+        origin: ThreadMessageOrigin::KeyboardHook,
+        msg: ThreadMessageType::RerenderUI,
+      });
+      let _ = state.tx_tray.send(ThreadMessage {
+        origin: ThreadMessageOrigin::KeyboardHook,
+        msg: ThreadMessageType::RerenderTray,
+      });
+
+      return CallbackResult::Drop;
+    }
+
+    // ---- Cmd+Esc / Ctrl+Esc → close app ----
+    if is_keydown
+      && keycode == VK_ESCAPE
+      && flags.intersects(CGEventFlags::CGEventFlagCommand | CGEventFlags::CGEventFlagControl)
+    {
+      let _ = state.tx_ui.send(ThreadMessage {
+        origin: ThreadMessageOrigin::KeyboardHook,
+        msg: ThreadMessageType::CloseApp,
+      });
+      return CallbackResult::Drop;
+    }
+
+    // Typing mode disabled → pass through
+    if !state.app_state.typing_enabled.load(Ordering::SeqCst) {
+      return CallbackResult::Keep;
+    }
+
+    // ---- Typing mode enabled ----
+
+    // Modifier-only keys and FlagsChanged → pass through
+    if is_modifier_key(keycode) || matches!(event_type, CGEventType::FlagsChanged) {
+      return CallbackResult::Keep;
+    }
+
+    // Key up → pass through
+    if !is_keydown {
+      return CallbackResult::Keep;
+    }
+
+    // Context-clearing keys
+    if is_context_clear_key(keycode) {
+      clear_context(&state);
+      return CallbackResult::Keep;
+    }
+
+    // Cmd/Ctrl/Option shortcuts → pass through
+    if flags.intersects(
+      CGEventFlags::CGEventFlagCommand
+        | CGEventFlags::CGEventFlagControl
+        | CGEventFlags::CGEventFlagAlternate,
+    ) {
+      clear_context(&state);
+      return CallbackResult::Keep;
+    }
+
+    // Convert to Unicode and process through typing context
+    let Some(text) = get_event_string(event) else {
+      return CallbackResult::Keep;
+    };
+
+    if text.chars().any(|ch| ch.is_control()) {
+      return CallbackResult::Keep;
+    }
+
+    // Lock discipline: release mutex BEFORE injecting (SendInput/post re-enters the hook)
+    let (total_delete, combined_add) = {
+      let mut guard = match state.app_state.typing_context.lock() {
+        Ok(g) => g,
+        Err(_) => return CallbackResult::Keep,
+      };
+
+      let mut total_delete: usize = 0;
+      let mut combined_add = String::new();
+
+      for ch in text.chars() {
+        let key = ch.to_string();
+        let diff = guard.take_key_input(&key);
+        total_delete += diff.to_delete_chars_count;
+        combined_add.push_str(&diff.diff_add_text);
+      }
+
+      (total_delete, combined_add)
+    };
+
+    if total_delete > 0 {
+      send_backspaces(total_delete);
+    }
+    if !combined_add.is_empty() {
+      send_unicode_text(&combined_add);
+    }
+
+    CallbackResult::Drop
+  }
+}

--- a/desktop-client/src/mac/mod.rs
+++ b/desktop-client/src/mac/mod.rs
@@ -1,0 +1,24 @@
+pub mod constants;
+pub mod hooks;
+pub mod runtime;
+
+use crossbeam_channel::Sender;
+use std::sync::Arc;
+
+use crate::{AppState, ThreadMessage};
+
+/// macOS-specific state bundling app state with message channels.
+/// Mirrors `WinAppState` in `win/mod.rs`.
+pub struct MacAppState {
+  pub app_state: Arc<AppState>,
+  pub tx_ui: Sender<ThreadMessage>,
+  pub tx_tray: Sender<ThreadMessage>,
+}
+
+pub fn run(
+  app_state: Arc<AppState>,
+  tx_ui: Sender<ThreadMessage>,
+  tx_tray: Sender<ThreadMessage>,
+) -> Result<(), Box<dyn std::error::Error>> {
+  runtime::run(app_state, tx_ui, tx_tray)
+}

--- a/desktop-client/src/mac/runtime.rs
+++ b/desktop-client/src/mac/runtime.rs
@@ -1,0 +1,51 @@
+use crossbeam_channel::Sender;
+use std::sync::Arc;
+
+use core_foundation::runloop::CFRunLoop;
+use core_graphics::event::{
+  CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement, CGEventType,
+};
+
+use super::MacAppState;
+
+pub fn run(
+  app_state: Arc<crate::AppState>,
+  tx_ui: Sender<crate::ThreadMessage>,
+  tx_tray: Sender<crate::ThreadMessage>,
+) -> Result<(), Box<dyn std::error::Error>> {
+  let mac_state = Arc::new(MacAppState {
+    app_state,
+    tx_ui,
+    tx_tray,
+  });
+
+  let callback = super::hooks::build_event_tap_callback(mac_state);
+
+  let events_of_interest = vec![
+    CGEventType::KeyDown,
+    CGEventType::KeyUp,
+    CGEventType::FlagsChanged,
+    CGEventType::LeftMouseDown,
+    CGEventType::RightMouseDown,
+    CGEventType::OtherMouseDown,
+  ];
+
+  CGEventTap::with_enabled(
+    CGEventTapLocation::HID,
+    CGEventTapPlacement::HeadInsertEventTap,
+    CGEventTapOptions::Default,
+    events_of_interest,
+    callback,
+    || CFRunLoop::run_current(),
+  )
+  .map_err(|()| {
+    std::io::Error::new(
+      std::io::ErrorKind::PermissionDenied,
+      "Failed to create CGEventTap. \
+       Please grant Accessibility permission: \
+       System Settings → Privacy & Security → Accessibility",
+    )
+  })?;
+
+  Ok(())
+}

--- a/desktop-client/src/mac/runtime.rs
+++ b/desktop-client/src/mac/runtime.rs
@@ -1,7 +1,7 @@
 use crossbeam_channel::Sender;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use core_foundation::runloop::CFRunLoop;
+use core_foundation::runloop::{CFRunLoop, kCFRunLoopCommonModes};
 use core_graphics::event::{
   CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement, CGEventType,
 };
@@ -19,7 +19,8 @@ pub fn run(
     tx_tray,
   });
 
-  let callback = super::hooks::build_event_tap_callback(mac_state);
+  let tap_port = Arc::new(Mutex::new(None));
+  let callback = super::hooks::build_event_tap_callback(mac_state, Arc::clone(&tap_port));
 
   let events_of_interest = vec![
     CGEventType::KeyDown,
@@ -30,14 +31,15 @@ pub fn run(
     CGEventType::OtherMouseDown,
   ];
 
-  CGEventTap::with_enabled(
-    CGEventTapLocation::HID,
-    CGEventTapPlacement::HeadInsertEventTap,
-    CGEventTapOptions::Default,
-    events_of_interest,
-    callback,
-    || CFRunLoop::run_current(),
-  )
+  let event_tap = unsafe {
+    CGEventTap::new_unchecked(
+      CGEventTapLocation::HID,
+      CGEventTapPlacement::HeadInsertEventTap,
+      CGEventTapOptions::Default,
+      events_of_interest,
+      callback,
+    )
+  }
   .map_err(|()| {
     std::io::Error::new(
       std::io::ErrorKind::PermissionDenied,
@@ -46,6 +48,18 @@ pub fn run(
        System Settings → Privacy & Security → Accessibility",
     )
   })?;
+
+  if let Ok(mut guard) = tap_port.lock() {
+    *guard = Some(event_tap.mach_port().clone());
+  }
+
+  let loop_source = event_tap
+    .mach_port()
+    .create_runloop_source(0)
+    .map_err(|()| std::io::Error::other("Failed to create CGEventTap run loop source"))?;
+  CFRunLoop::get_current().add_source(&loop_source, unsafe { kCFRunLoopCommonModes });
+  event_tap.enable();
+  CFRunLoop::run_current();
 
   Ok(())
 }

--- a/desktop-client/src/platform.rs
+++ b/desktop-client/src/platform.rs
@@ -2,6 +2,10 @@
 #[path = "win/mod.rs"]
 mod win;
 
+#[cfg(target_os = "macos")]
+#[path = "mac/mod.rs"]
+mod mac;
+
 use crossbeam_channel::Sender;
 use std::sync::Arc;
 
@@ -15,7 +19,12 @@ pub fn run(
     win::run(_app_state, _tx_ui, _tx_tray).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
   }
 
-  #[cfg(not(windows))]
+  #[cfg(target_os = "macos")]
+  {
+    mac::run(_app_state, _tx_ui, _tx_tray)
+  }
+
+  #[cfg(not(any(windows, target_os = "macos")))]
   {
     Err(
       std::io::Error::new(


### PR DESCRIPTION
- **init**
- **review**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native macOS support to the desktop client
  * Implemented keyboard event interception and intelligent input handling with typing mode management
  * Added keyboard shortcuts for toggling typing features and controlling the application
  * Enhanced input processing with modifier key support and context-aware event filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->